### PR TITLE
Trap SignalExceptions in Job.reserve

### DIFF
--- a/lib/tom_queue/delayed_job/job.rb
+++ b/lib/tom_queue/delayed_job/job.rb
@@ -336,6 +336,12 @@ module TomQueue
         
         nil
 
+      rescue SignalException => e
+
+        error "[reserve] SignalException in reserve method: #{e.message}."
+
+        nil
+
       rescue Exception => e
 
         error "[reserve] Exception in reserve method: #{e.message}."

--- a/spec/tom_queue/delayed_job/delayed_job_spec.rb
+++ b/spec/tom_queue/delayed_job/delayed_job_spec.rb
@@ -614,11 +614,19 @@ describe TomQueue, "once hooked" do
         Delayed::Worker.raise_signal_exceptions.should == true
       end
 
-      it "should allow exceptions to escape the function" do
+      it "should not allow signal exceptions to escape the function" do
         Delayed::Job.tomqueue_manager.should_receive(:pop) do
           raise SignalException, "INT"
         end
-        lambda { subject }.should raise_exception(SignalException)
+
+        lambda { subject }.should_not raise_exception(SignalException)
+      end
+
+      it "should allow exceptions to escape the function" do
+        Delayed::Job.tomqueue_manager.should_receive(:pop) do
+          raise Exception, "Something went wrong"
+        end
+        lambda { subject }.should raise_exception(Exception)
       end
     end
 


### PR DESCRIPTION
Delayed Job [handles trapping the signals and acting upon the signal](https://github.com/collectiveidea/delayed_job/blob/v4.0.0/lib/delayed/worker.rb#L135-L145), but we get raised the `SignalException` due to our setting of `Delayed::Worker.raise_signal_exceptions` to true. And then let that bubble out to the error handler.

Instead, now log that we saw a `SignalException`, but don't let it bubble out of `TomQueue::DelayedJob::Job.reserve`.
