### PR TITLE
Publish to topic exchange from QueueManager

### DIFF
--- a/lib/tom_queue/queue_manager.rb
+++ b/lib/tom_queue/queue_manager.rb
@@ -165,7 +165,7 @@ module TomQueue
         
         debug "[publish] Pushing work onto exchange '#{@exchange.name}' with routing key '#{priority}'"
         @publisher_mutex.synchronize do
-          @publisher_channel.direct(@exchange.name, :passive=>true).publish(work, {
+          @publisher_channel.topic(@exchange.name, :passive=>true).publish(work, {
             :routing_key => priority,
             :headers => {
               :job_priority => priority,


### PR DESCRIPTION
Previously we created a topic exchange, then told bunny to publish to a direct exchange. Bunny ignored us and did the right thing because we passed `passive: true` and didn't try to recreate the exchange.

Lets do the right thing instead.
