### PR TITLE
WIP - on exception fetching amqp payload nack message

### DIFF
--- a/lib/tom_queue/delayed_job/job.rb
+++ b/lib/tom_queue/delayed_job/job.rb
@@ -333,18 +333,20 @@ module TomQueue
         error "[reserve] Failed to parse JSON payload: #{e.message}. Dropping AMQP message."
 
         TomQueue.exception_reporter && TomQueue.exception_reporter.notify(e)
-        
+
         nil
 
       rescue SignalException => e
 
-        error "[reserve] SignalException in reserve method: #{e.message}."
+        work.nack!
+        error "[reserve] SignalException in reserve method, nacked work (will be requeued): #{e.message}."
 
         nil
 
       rescue Exception => e
 
-        error "[reserve] Exception in reserve method: #{e.message}."
+        work.nack!
+        error "[reserve] Exception in reserve method, nacked work (will be requeued): #{e.message}."
         TomQueue.exception_reporter && TomQueue.exception_reporter.notify(e)
 
         raise

--- a/lib/tom_queue/delayed_job/job.rb
+++ b/lib/tom_queue/delayed_job/job.rb
@@ -338,14 +338,14 @@ module TomQueue
 
       rescue SignalException => e
 
-        work.nack!
+        work && work.nack!
         error "[reserve] SignalException in reserve method, nacked work (will be requeued): #{e.message}."
 
         nil
 
       rescue Exception => e
 
-        work.nack!
+        work && work.nack!
         error "[reserve] Exception in reserve method, nacked work (will be requeued): #{e.message}."
         TomQueue.exception_reporter && TomQueue.exception_reporter.notify(e)
 

--- a/lib/tom_queue/queue_manager.rb
+++ b/lib/tom_queue/queue_manager.rb
@@ -187,6 +187,17 @@ module TomQueue
       work
     end
 
+    # Public: Reject some work
+    #
+    # work - the TomQueue::Work object to acknowledge
+    # requeue - boolean, wether to requeue the work or drop it
+    #
+    # Returns the work object passed.
+    def nack(work, requeue = true)
+      @channel.nack(work.response.delivery_tag, false, requeue)
+      work
+    end
+
     # Public: Pop some work off the queue
     #
     # This call will block, if necessary, until work becomes available.

--- a/lib/tom_queue/queue_manager.rb
+++ b/lib/tom_queue/queue_manager.rb
@@ -190,7 +190,7 @@ module TomQueue
     # Public: Reject some work
     #
     # work - the TomQueue::Work object to acknowledge
-    # requeue - boolean, wether to requeue the work or drop it
+    # requeue - boolean, whether to requeue the work or drop it
     #
     # Returns the work object passed.
     def nack(work, requeue = true)

--- a/lib/tom_queue/queue_manager.rb
+++ b/lib/tom_queue/queue_manager.rb
@@ -10,7 +10,7 @@ module TomQueue
   #
   # The scheduler simply trumps lower-priority jobs with higher
   # priority jobs. So ensure you don't saturate the worker with many
-  # or lengthy high priority jobs as you'll negatively impact normal 
+  # or lengthy high priority jobs as you'll negatively impact normal
   # and bulk jobs.
   #
   # HIGH_PRIORITY - use where the job is relatively short and the
@@ -20,7 +20,7 @@ module TomQueue
   # NORMAL_PRIORITY - use for longer-interactive tasks (rebuilding ledgers?)
   #
   # BULK_PRIORITY - typically when you want to schedule lots of work to be done
-  #   at some point in the future - background emailing, cron-triggered 
+  #   at some point in the future - background emailing, cron-triggered
   #   syncs, etc.
   #
   HIGH_PRIORITY = "high"
@@ -52,18 +52,18 @@ module TomQueue
 
     # Internal: The work queues used by consumers
     #
-    # Internal, this is an implementation detail. Accessor is mainly for 
+    # Internal, this is an implementation detail. Accessor is mainly for
     # convenient testing
-    # 
+    #
     # Returns a hash of { "priority" => <Bunny::Queue>, ... }
     attr_reader :queues
 
     # Internal: The exchange to which work is published
     #
-    # Internal, this is an implementation detail. Accessor is mainly for 
+    # Internal, this is an implementation detail. Accessor is mainly for
     # convenient testing
     #
-    # Returns Bunny::Exchange instance. 
+    # Returns Bunny::Exchange instance.
     attr_reader :exchange
 
     class PersistentWorkPool < ::Bunny::ConsumerWorkPool
@@ -78,7 +78,7 @@ module TomQueue
     # name  - used as a prefix for AMQP exchanges and queues.
     #         (this will default to TomQueue.default_prefix if set)
     #
-    # NOTE: All consumers and producers sharing work must have the same 
+    # NOTE: All consumers and producers sharing work must have the same
     #       prefix value.
     #
     # Returns an instance, duh!
@@ -103,7 +103,7 @@ module TomQueue
 
     # Internal: Opens channels and declares the necessary queues, exchanges and bindings
     #
-    # As a convenience to tests, this will tear-down any existing connections, so it is 
+    # As a convenience to tests, this will tear-down any existing connections, so it is
     # possible to simulate a failed connection by calling this a second time.
     #
     # Retunrs nil
@@ -113,7 +113,7 @@ module TomQueue
       @publisher_channel && @publisher_channel.close
       @channel && @channel.close
 
-      # Publishing is going to come in from the host app, as well as 
+      # Publishing is going to come in from the host app, as well as
       # the Deferred thread, so create a dedicated channel and mutex
       @publisher_channel = Bunny::Channel.new(@bunny, nil, @work_pool)
       @publisher_channel.open
@@ -121,7 +121,7 @@ module TomQueue
 
       @channel = Bunny::Channel.new(@bunny, nil, @work_pool)
       @channel.open
-      @channel.prefetch(1)
+      @channel.basic_qos(1, true)
 
       @queues = {}
 
@@ -162,7 +162,7 @@ module TomQueue
           :run_at   => run_at
         })
       else
-        
+
         debug "[publish] Pushing work onto exchange '#{@exchange.name}' with routing key '#{priority}'"
         @publisher_mutex.synchronize do
           @publisher_channel.topic(@exchange.name, :passive=>true).publish(work, {
@@ -180,7 +180,7 @@ module TomQueue
     # Public: Acknowledge some work
     #
     # work - the TomQueue::Work object to acknowledge
-    # 
+    #
     # Returns the work object passed.
     def ack(work)
       @channel.ack(work.response.delivery_tag)

--- a/lib/tom_queue/work.rb
+++ b/lib/tom_queue/work.rb
@@ -63,7 +63,7 @@ module TomQueue
     #
     # Returns self
     def nack!(requeue = true)
-      @manager.nack(self)
+      @manager.nack(self, requeue)
     end
   end
 

--- a/lib/tom_queue/work.rb
+++ b/lib/tom_queue/work.rb
@@ -57,6 +57,14 @@ module TomQueue
       @manager.ack(self)
       self
     end
+
+    # Public: Reject this message, with a nack (not acked). Optionally re-queue the message
+    # or just drop it if requeue == false
+    #
+    # Returns self
+    def nack!(requeue = true)
+      @manager.nack(self)
+    end
   end
 
 end


### PR DESCRIPTION
- On expception while attempting to fetch an amqp payload ensure we nack
  the message and requeue it. Otherwise this thread get's hung up
  because it never acks or nacks the "in flight" payload.

No Tests, not even run or syntax checked, just got distracted...