### PR TITLE
Add hook to allow overriding publish method, and provide Stomp publisher class

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,5 @@
+require 'rspec/core/rake_task'
+
+RSpec::Core::RakeTask.new(:spec)
+
+task :default => :spec

--- a/lib/tom_queue/stomp_publisher.rb
+++ b/lib/tom_queue/stomp_publisher.rb
@@ -1,0 +1,66 @@
+require "stomp"
+
+module TomQueue
+  # Public: publishes RMQ messages via Stomp
+  #
+  # Plug into TomQueue with the following:
+  #
+  #     TomQueue::QueueManager.publisher = TomQueue::StompPublisher.new(config)
+  #
+  # IMPORTANT: This publisher **cannot** create the exchanges or queue bindings,
+  # these MUST be created elsewhere before we can publish messages and have them
+  # routed.
+  #
+  class StompPublisher
+
+    # Internal: wraps an "exchange" as a return object from StompPublisher#topic
+    #
+    # Lets us hold relevant details for the exchange we want to publish to, and
+    # also defines #publish as required by TomQueue::QueueManager.publisher
+    #
+    class ExchangeWrapper
+      attr_reader :exchange_name
+
+      def initialize(stomp_publisher, exchange_name)
+        @stomp_publisher = stomp_publisher
+        @exchange_name = exchange_name.freeze
+      end
+
+      # Public: publishes the message to the exchange
+      #
+      # message [String] body of RMQ message
+      # options [Hash] 
+      #
+      # Returns Stomp::Client#publish return value
+      def publish(message, key: nil, headers: {})
+        stomp_publisher.client.publish(stomp_exchange(name: exchange_name, key: key), message, headers)
+      end
+
+      private
+
+      attr_reader :stomp_publisher
+
+      def stomp_exchange(name:, key: nil)
+        "/exchange/#{name}".tap {|e| e << "/#{key}" if key }
+      end
+    end
+
+    attr_reader :stomp_config
+
+    def initialize(stomp_config:)
+      @stomp_config = stomp_config
+    end
+
+    # Public: fakes creation of the topic exchange
+    #
+    # Returns ExchangeWrapper instance which responds to #publish
+    def topic(exchange_name, _options = {})
+      ExchangeWrapper.new(self, exchange_name)
+    end
+
+    def client
+      @client ||= Stomp::Client.new(stomp_config)
+    end
+
+  end
+end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -11,6 +11,15 @@ require 'delayed/backend/shared_spec'
 Delayed::Worker.logger = Logger.new('/tmp/dj.log')
 ENV['RAILS_ENV'] = 'test'
 
+RSpec.configure do |config|
+  config.color = true
+
+  config.mock_with :rspec
+
+  config.expect_with :rspec do |expect|
+    expect.syntax = [:should, :expect]
+  end
+end
 
 db_adapter, gemfile = ENV["ADAPTER"], ENV["BUNDLE_GEMFILE"]
 db_adapter ||= gemfile && gemfile[%r(gemfiles/(.*?)/)] && $1

--- a/spec/tom_queue/stomp_publisher_spec.rb
+++ b/spec/tom_queue/stomp_publisher_spec.rb
@@ -1,0 +1,68 @@
+require "helper"
+
+begin
+  require "tom_queue/stomp_publisher"
+
+  describe TomQueue::StompPublisher do
+
+    let(:publisher) { TomQueue::StompPublisher.new(:stomp_config => {}) }
+
+    describe "#initialize" do
+      it "requires stomp_config" do
+        expect { TomQueue::StompPublisher.new }.to raise_error(ArgumentError)
+      end
+    end
+
+    describe "#topic" do
+      describe "arguments" do
+        it "requires the exchange name" do
+          expect { publisher.topic }.to raise_error(ArgumentError)
+          expect { publisher.topic("name") }.not_to raise_error
+        end
+
+        it "optionally accepts exchange options as second argument" do
+          expect { publisher.topic("name", :blah => true, :foo => false) }.not_to raise_error
+        end
+      end
+
+      describe "return value" do
+        let(:result) { publisher.topic("champagne") }
+
+        it "knows the exchange it represents" do
+          expect(result.exchange_name).to eq("champagne")
+        end
+
+        it "responds to #publish" do
+          expect(result).to respond_to(:publish)
+        end
+      end
+    end
+
+    describe "#publish" do
+      let(:client) { double(Stomp::Client) }
+      let(:exchange) { publisher.topic("champagne") }
+      before { publisher.instance_variable_set(:@client, client) }
+
+      it "publishes a basic message to the exchange" do
+        expect(client).to receive(:publish).with("/exchange/champagne", "superduper", {})
+
+        exchange.publish("superduper")
+      end
+
+      it "publishes a routed message to the exchange" do
+        expect(client).to receive(:publish).with("/exchange/champagne/supernova", "superduper", {})
+
+        exchange.publish("superduper", key: "supernova")
+      end
+
+      it "publishes with custom message headers" do
+        expect(client).to receive(:publish).with("/exchange/champagne", "superduper", {run_at: 9001})
+
+        exchange.publish("superduper", headers: {run_at: 9001})
+      end
+    end
+
+  end
+rescue LoadError => e
+  # Not running this spec if we can't load in active_rabbit
+end

--- a/tom_queue.gemspec
+++ b/tom_queue.gemspec
@@ -20,4 +20,5 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency('rest-client')
   spec.add_development_dependency('rake')
+  spec.add_development_dependency("stomp")
 end

--- a/tom_queue.gemspec
+++ b/tom_queue.gemspec
@@ -19,4 +19,5 @@ Gem::Specification.new do |spec|
   spec.version        = '0.0.1.dev'
 
   spec.add_development_dependency('rest-client')
+  spec.add_development_dependency('rake')
 end

--- a/tom_queue.gemspec
+++ b/tom_queue.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 
 Gem::Specification.new do |spec|
-  spec.add_dependency   'activerecord', '~> 4.2'
+  spec.add_dependency   'activerecord', '>= 4.1'
   spec.add_dependency   'delayed_job_active_record'
   spec.add_dependency   'bunny', '1.0.5'
   spec.authors        = ["Thomas Haggett"]
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files     = Dir.glob("spec/**/*")
   spec.version        = '0.0.1.dev'
 
+  spec.add_development_dependency "activerecord", "~> 4.2"
   spec.add_development_dependency('rest-client')
   spec.add_development_dependency('rake')
   spec.add_development_dependency("stomp")


### PR DESCRIPTION
We add a hook at `TomQueue::QueueManager.publisher` to allow us to configure a different mechanism for publishing messages, as opposed to using `TomQueue.bunny` & AMQP.

We also provide a `TomQueue::StompPublisher` class which wraps the [Stomp](https://github.com/stompgem/stomp) gem to be API-compatible with what `QueueManager.publisher` expects. This in turn lets us have TomQueue publish DJ notifications to the workers via Stomp.

The major caveat here is that we cannot declare the RMQ exchanges or bind queues over Stomp. However, as the DJ workers will be booted & still using bunny/AMQP, they can declare the exchanges & queue bindings for us, and then we can just publish using Stomp protocol.

The aim of doing this is to use the simpler failover logic between two RMQ nodes in Stomp (the gem), to handle the situation of a node going away & coming back.