### PR TITLE
Make sure that DeferredWorkManager can be shutdown gracefully

### DIFF
--- a/lib/tom_queue/deferred_work_manager.rb
+++ b/lib/tom_queue/deferred_work_manager.rb
@@ -136,7 +136,7 @@ module TomQueue
     def handle_signals
       sig = Thread.main[:signals].shift
       if sig
-        logger.info "Caught signal #{sig}, stopping deffered workers"
+        info "Caught signal #{sig}, stopping deffered workers"
         stop
       end
     end

--- a/lib/tom_queue/deferred_work_manager.rb
+++ b/lib/tom_queue/deferred_work_manager.rb
@@ -136,7 +136,7 @@ module TomQueue
     def handle_signals
       sig = Thread.main[:signals].shift
       if sig
-        info "Caught signal #{sig}, stopping deffered workers"
+        info "Caught signal #{sig}, stopping deferred workers..."
         stop
       end
     end


### PR DESCRIPTION
Make sure that DeferredWorkManager can be shutdown gracefully itself, rather than being supervised by scripting.