### PR TITLE
Reuse immediate work exchange

### DIFF
--- a/lib/tom_queue/queue_manager.rb
+++ b/lib/tom_queue/queue_manager.rb
@@ -166,7 +166,7 @@ module TomQueue
 
     def publish_immediate(work, run_at, priority)
       debug "[publish] Pushing work onto exchange '#{@exchange.name}' with routing key '#{priority}'"
-      @publisher_channel.topic(@exchange.name, :passive=>true).publish(work, {
+      @exchange.publish(work, {
           :routing_key => priority,
           :headers => {
             :job_priority => priority,

--- a/spec/tom_queue/delayed_job/delayed_job_spec.rb
+++ b/spec/tom_queue/delayed_job/delayed_job_spec.rb
@@ -308,6 +308,7 @@ describe TomQueue, "once hooked" do
       queue.message_count.should == 0
 
       Delayed::Job.tomqueue_republish
+      sleep 0.25
       queue.message_count.should == 10
     end
 
@@ -320,6 +321,7 @@ describe TomQueue, "once hooked" do
       queue.message_count.should == 0
 
       Delayed::Job.where('id IN (?)', second_ids).tomqueue_republish
+      sleep 0.25
       queue.message_count.should == 7
     end
 

--- a/spec/tom_queue/tom_queue_integration_spec.rb
+++ b/spec/tom_queue/tom_queue_integration_spec.rb
@@ -4,7 +4,7 @@ require 'tom_queue/helper'
 
 describe TomQueue::QueueManager, "simple publish / pop" do
 
-  let(:manager) { TomQueue::QueueManager.new("test-#{Time.now.to_f}", 'manager') }
+  let(:manager) { TomQueue::QueueManager.new(TomQueue.default_prefix, 'manager') }
   let(:consumer) { TomQueue::QueueManager.new(manager.prefix, 'consumer1') }
   let(:consumer2) { TomQueue::QueueManager.new(manager.prefix, 'consumer2') }
 
@@ -132,7 +132,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
     consumer2.pop.ack!.payload.should == "stuff 3"
   end
 
-  it "should allow a message to be deferred for future execution" do
+  it "should allow a message to be deferred for future execution", deferred_work_manager: true do
     execution_time = Time.now + 0.2
     manager.publish("future-work", :run_at => execution_time )
 
@@ -260,7 +260,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
       Set.new(sink_order).should == Set.new(source_order)
     end
 
-    it "should work with lots of deferred work on the queue, and still schedule all messages" do
+    it "should work with lots of deferred work on the queue, and still schedule all messages", deferred_work_manager: true do
       # sit in a loop to pop it all off again
       consumers = 5.times.collect do |i|
         consumer = TomQueue::QueueManager.new(manager.prefix, "thread-#{i}")


### PR DESCRIPTION
TomQueue was redeclaring the topic exchange every time it republished a message.

Bunny doesn't recover from timeout errors that occur when declaring exchanges which can lead to lost messages.

Reusing the exchange should mean that we can recover from network errors that occur while publishing messages.

Also fixed the specs, which look like they were broken when the deferred work manager was extracted.