### PR TITLE
Destroy jobs and then acknowledge the rabbitmq message.

### DIFF
--- a/lib/tom_queue/delayed_job/job.rb
+++ b/lib/tom_queue/delayed_job/job.rb
@@ -65,6 +65,8 @@ module TomQueue
       include TomQueue::LoggingHelper
       include TomQueue::DelayedJob::ExternalMessages
 
+      after_commit :acknowledge_destroyed_jobs
+
       # Public: This provides a shared queue manager object, instantiated on
       # the first call
       #
@@ -366,16 +368,9 @@ module TomQueue
       # Returns nil or TomQueue::Work object
       attr_accessor :tomqueue_work
 
-      # Internal: This wraps the job invocation with an acknowledgement of the original
-      # TomQueue work object, if one is around.
-      #
-      def invoke_job
-        super
-      ensure
-        debug "[invoke job:#{self.id}] Invoke completed, acking message."
-        self.tomqueue_work && self.tomqueue_work.ack!
+      def acknowledge_destroyed_jobs
+        tomqueue_work.ack! if tomqueue_work && !persisted?
       end
-
     end
   end
 end

--- a/spec/tom_queue/delayed_job/delayed_job_spec.rb
+++ b/spec/tom_queue/delayed_job/delayed_job_spec.rb
@@ -861,25 +861,19 @@ describe TomQueue, "once hooked" do
       job.invoke_job
     end
 
-    describe "if there is a tomqueue work object set on the object" do
-      let(:work_object) { double("WorkObject", :ack! => nil)}
-      before { job.tomqueue_work = work_object}
-
-      it "should call ack! on the work object after the job has been invoked" do
-        payload.should_receive(:perform).ordered
-        work_object.should_receive(:ack!).ordered
-        job.invoke_job
-      end
-
-      it "should call ack! on the work object if an exception is raised" do
-        payload.should_receive(:perform).ordered.and_raise(RuntimeError, "OMG!!!11")
-        work_object.should_receive(:ack!).ordered
-        lambda {
-          job.invoke_job
-        }.should raise_exception(RuntimeError, "OMG!!!11")
-      end
-    end
   end
 
+  describe "Job#destroy" do
+    let(:payload) { double("DelayedJobPayload", :perform => nil)}
+    let(:job) { Delayed::Job.create!(:payload_object=>payload) }
+
+    let(:work_object) { double("WorkObject", :ack! => nil)}
+    before { job.tomqueue_work = work_object}
+
+    it "should call ack! on the work object after the job has been destroyed" do
+      work_object.should_receive(:ack!).ordered
+      job.destroy
+    end
+  end
 
 end


### PR DESCRIPTION
To ensure that jobs are not left in the database without a corresponding message
in rabbitmq, move the ack to an after_commit hook that checks that the message
has been destroyed.