### PR TITLE
Handle signal exception properly

### DIFF
--- a/lib/tom_queue/deferred_work_manager.rb
+++ b/lib/tom_queue/deferred_work_manager.rb
@@ -32,7 +32,6 @@ module TomQueue
       setup_amqp
       @deferred_set = DeferredWorkSet.new
       @out_manager = QueueManager.new(prefix)
-      @shutdown = false
     end
 
 
@@ -87,7 +86,7 @@ module TomQueue
       # (which have been scheduled by the AMQP consumer). If a message is returned
       # then we re-publish the messages to our internal QueueManager and ack the deferred
       # message
-      while true
+      loop do
         # This will block until work is ready to be returned, interrupt
         # or the 10-second timeout value.
         response, headers, payload = deferred_set.pop(2)
@@ -102,8 +101,6 @@ module TomQueue
     rescue SignalException
       consumer.cancel
       channel && channel.close
-
-      deferred_set && deferred_set.interrupt
     rescue Exception => e
       error e
       reporter = TomQueue.exception_reporter

--- a/lib/tom_queue/deferred_work_manager.rb
+++ b/lib/tom_queue/deferred_work_manager.rb
@@ -87,7 +87,7 @@ module TomQueue
       # (which have been scheduled by the AMQP consumer). If a message is returned
       # then we re-publish the messages to our internal QueueManager and ack the deferred
       # message
-      until @shutdown
+      while true
         # This will block until work is ready to be returned, interrupt
         # or the 10-second timeout value.
         response, headers, payload = deferred_set.pop(2)
@@ -99,20 +99,15 @@ module TomQueue
           channel.ack(response.delivery_tag)
         end
       end
-
+    rescue SignalException
       consumer.cancel
       channel && channel.close
+
+      deferred_set && deferred_set.interrupt
     rescue Exception => e
       error e
       reporter = TomQueue.exception_reporter
       reporter && reporter.notify($!)
     end
-
-    def stop
-      @shutdown = true
-      deferred_set && deferred_set.interrupt
-    end
-
   end
-
 end

--- a/lib/tom_queue/deferred_work_set.rb
+++ b/lib/tom_queue/deferred_work_set.rb
@@ -1,9 +1,9 @@
 module TomQueue
 
-  # Internal: This class wraps the pool of work items that are waiting for their run_at 
+  # Internal: This class wraps the pool of work items that are waiting for their run_at
   # time to be reached.
-  # 
-  # It also incorporates the logic and coordination required to stall a thread until the 
+  #
+  # It also incorporates the logic and coordination required to stall a thread until the
   # work is ready to run.
   #
   class DeferredWorkSet
@@ -30,7 +30,7 @@ module TomQueue
       # Internal: Comparison function, referencing the scheduled run-time of the element
       #
       # NOTE: We don't compare the Time objects directly as this is /dog/ slow, as is comparing
-      # float objects, and this function will be called a /lot/ - so we compare reasonably 
+      # float objects, and this function will be called a /lot/ - so we compare reasonably
       # accurate integer values created in the initializer.
       #
       def <=> (other)
@@ -41,7 +41,7 @@ module TomQueue
       # too soon.
       #
       # When #<=> is used with `Comparable`, we get #== for free, but when it operates using run_at, it has
-      # the undesirable side-effect that when Array#delete is called with an element, all other elements with 
+      # the undesirable side-effect that when Array#delete is called with an element, all other elements with
       # the same run_at are deleted, too (since #== is used by Array#delete).
       #
       def == (other)
@@ -66,7 +66,7 @@ module TomQueue
     # or the timeout expires.
     #
     # This is intended to be called from a single worker thread, for the
-    # time being, if you try and block on this method concurrently in 
+    # time being, if you try and block on this method concurrently in
     # two threads, it will raise an exception!
     #
     # timeout - (Fixnum, seconds) how long to wait before timing out
@@ -76,8 +76,6 @@ module TomQueue
     def pop(timeout)
       timeout_end = Time.now + timeout
       returned_work = nil
-
-      @interrupt = false
 
       @mutex.synchronize do
         raise RuntimeError, 'DeferredWorkSet: another thread is already blocked on a pop' unless @blocked_thread.nil?
@@ -89,7 +87,7 @@ module TomQueue
             end_time = [next_run_at, timeout_end].compact.min
             delay = end_time - Time.now
             @condvar.wait(@mutex, delay) if delay > 0
-          end while Time.now < end_time and @interrupt == false
+          end while Time.now < end_time
 
           element = earliest_element
           if element && element.run_at < Time.now
@@ -103,18 +101,6 @@ module TomQueue
       end
 
       returned_work
-    end
-    
-    # Public: Interrupt anything sleeping on this set
-    #
-    # This is "thread-safe" and is designed to be called from threads
-    # to interrupt the work loop thread blocked on a pop.
-    #
-    def interrupt
-      @mutex.synchronize do
-        @interrupt = true
-        @condvar.signal
-      end
     end
 
     # Public: Add some work to the set

--- a/lib/tom_queue/version.rb
+++ b/lib/tom_queue/version.rb
@@ -1,0 +1,3 @@
+module TomQueue
+  VERSION = "1.0.0"
+end

--- a/spec/tom_queue/deferred_work/deferred_work_manager_integration_spec.rb
+++ b/spec/tom_queue/deferred_work/deferred_work_manager_integration_spec.rb
@@ -32,11 +32,11 @@ describe "DeferredWorkManager", "#stop" do
     sleep 0.2
 
     Process.kill("SIGTERM", pid)
-    Process.waitpid(pid)
+    _, @status = Process.waitpid2(pid)
   end
 
   it "handles SIGTERM send by god properly" do
-    expect($?.exitstatus).to eq 0
+    expect(@status.exitstatus).to eq 0
   end
 
   it "doesn't report into the exception_reporter" do

--- a/spec/tom_queue/deferred_work/deferred_work_manager_integration_spec.rb
+++ b/spec/tom_queue/deferred_work/deferred_work_manager_integration_spec.rb
@@ -2,6 +2,24 @@ require 'tom_queue/helper'
 
 # "Integration" For lack of a better word, trying to simulate various failures
 
+describe "DeferredWorkManager", "#stop" do
+  it "stops the thread" do
+    pid = fork do
+      TomQueue.bunny = Bunny.new(TEST_AMQP_CONFIG)
+      TomQueue.bunny.start
+      manager = TomQueue::DeferredWorkManager.new(TomQueue.default_prefix)
+      manager.start
+    end
+
+    sleep 0.5
+
+    expect {
+      Process.kill("SIGTERM", pid)
+    }.to_not raise_error
+
+  end
+end
+
 describe "DeferredWorkManager integration scenarios"  do
   it "should restore un-acked messages when the process has crashed" do
     @prefix = "test-#{Time.now.to_f}"

--- a/spec/tom_queue/deferred_work/deferred_work_manager_integration_spec.rb
+++ b/spec/tom_queue/deferred_work/deferred_work_manager_integration_spec.rb
@@ -3,7 +3,7 @@ require 'tom_queue/helper'
 # "Integration" For lack of a better word, trying to simulate various failures
 
 describe "DeferredWorkManager", "#stop" do
-  it "stops the thread" do
+  it "handles SIGTERM sends by god properly" do
     pid = fork do
       TomQueue.bunny = Bunny.new(TEST_AMQP_CONFIG)
       TomQueue.bunny.start
@@ -11,12 +11,12 @@ describe "DeferredWorkManager", "#stop" do
       manager.start
     end
 
-    sleep 0.5
+    sleep 1
 
-    expect {
-      Process.kill("SIGTERM", pid)
-    }.to_not raise_error
-
+    expect(TomQueue).to_not receive(:exception_reporter)
+    Process.kill("SIGTERM", pid)
+    Process.waitpid(pid)
+    expect($?.exitstatus).to eq 0
   end
 end
 

--- a/spec/tom_queue/deferred_work/deferred_work_set_spec.rb
+++ b/spec/tom_queue/deferred_work/deferred_work_set_spec.rb
@@ -79,16 +79,6 @@ describe TomQueue::DeferredWorkSet do
       set.pop(10).should == "work"
     end
 
-    it "should return immediately if it is interrupted by an external thread" do
-      Thread.new { sleep 0.1; set.interrupt }
-      start_time = Time.now
-      set.schedule(start_time + 1.5, "work")
-      set.schedule(start_time + 5, "work")
-      set.pop(10)
-      Time.now.should > start_time + 0.1
-      Time.now.should < start_time + 0.2
-    end
-
     it "should block until the earliest work, even if earlier work is added after the block" do
       start_time = Time.now
       Thread.new do

--- a/tom_queue.gemspec
+++ b/tom_queue.gemspec
@@ -1,5 +1,7 @@
 # coding: utf-8
 
+require_relative "lib/tom_queue/version"
+
 Gem::Specification.new do |spec|
   spec.add_dependency   'activerecord', '~> 4.1'
   spec.add_dependency   'delayed_job_active_record'
@@ -16,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.require_paths  = ['lib']
   spec.summary        = 'AMQP hook for ActiveRecord backend for DelayedJob'
   spec.test_files     = Dir.glob("spec/**/*")
-  spec.version        = '0.0.3'
+  spec.version        = TomQueue::VERSION
 
   spec.add_development_dependency('rest-client')
 end


### PR DESCRIPTION
God sends a `SIGTERM` to TomQueue when a deploy happens. This is not properly handled by TomQueue and it fails hard. 
This also allows us to clean up the code a bit by removing the logic around `stop` which becomes useless.