### PR TITLE
Don't attempt to catch exceptions in acquire_locked_job

### DIFF
--- a/lib/tom_queue/delayed_job/job.rb
+++ b/lib/tom_queue/delayed_job/job.rb
@@ -256,12 +256,6 @@ module TomQueue
             job
 
           end
-        rescue => e
-          if e.class.to_s =~ /^RSpec/
-            raise
-          else
-            record.logger.error(e) if record.respond_to?(:logger) && record.logger
-          end
         end
       end
 

--- a/lib/tom_queue/version.rb
+++ b/lib/tom_queue/version.rb
@@ -1,3 +1,3 @@
 module TomQueue
-  VERSION = "1.0.0"
+  VERSION = "1.0.1"
 end


### PR DESCRIPTION
As `record` doesn't exist this block would always raise an exception, but we would lose the real cause.

Let's not rescue for now and see what exception are being raised.