### PR TITLE
Ack work after the job has been destroyed

### DIFF
--- a/lib/tom_queue/delayed_job.rb
+++ b/lib/tom_queue/delayed_job.rb
@@ -1,6 +1,7 @@
 module TomQueue
   module DelayedJob
 
+    require 'tom_queue/delayed_job/ack_work_plugin'
     require 'tom_queue/delayed_job/external_messages'
     require 'tom_queue/delayed_job/job'
 
@@ -12,7 +13,7 @@ module TomQueue
 
     # Public: This installs the dynamic patches into Delayed Job to move scheduling over
     # to AMQP. Generally, this should be called during a Rails initializer at some point.
-    def apply_hook!    
+    def apply_hook!
       Delayed::Worker.sleep_delay = 0
       Delayed::Worker.backend = TomQueue::DelayedJob::Job
     end
@@ -30,4 +31,3 @@ module TomQueue
 
   end
 end
-

--- a/lib/tom_queue/delayed_job/ack_work_plugin.rb
+++ b/lib/tom_queue/delayed_job/ack_work_plugin.rb
@@ -1,0 +1,15 @@
+require 'active_support/concern'
+
+module TomQueue
+  module DelayedJob
+    class AckWorkPlugin < Delayed::Plugin
+      callbacks do |lifecycle|
+        lifecycle.after(:perform) do |_, job|
+          job.tomqueue_work.ack! if job.tomqueue_work
+        end
+      end
+
+      Delayed::Worker.plugins << self
+    end
+  end
+end

--- a/lib/tom_queue/delayed_job/job.rb
+++ b/lib/tom_queue/delayed_job/job.rb
@@ -360,16 +360,6 @@ module TomQueue
       # Returns nil or TomQueue::Work object
       attr_accessor :tomqueue_work
 
-      # Internal: This wraps the job invocation with an acknowledgement of the original
-      # TomQueue work object, if one is around.
-      #
-      def invoke_job
-        super
-      ensure
-        debug "[invoke job:#{self.id}] Invoke completed, acking message."
-        self.tomqueue_work && self.tomqueue_work.ack!
-      end
-
     end
   end
 end

--- a/lib/tom_queue/version.rb
+++ b/lib/tom_queue/version.rb
@@ -1,3 +1,3 @@
 module TomQueue
-  VERSION = "1.0.1"
+  VERSION = "1.0.2"
 end

--- a/spec/tom_queue/delayed_job/delayed_job_spec.rb
+++ b/spec/tom_queue/delayed_job/delayed_job_spec.rb
@@ -860,25 +860,6 @@ describe TomQueue, "once hooked" do
       job.tomqueue_work = nil
       job.invoke_job
     end
-
-    describe "if there is a tomqueue work object set on the object" do
-      let(:work_object) { double("WorkObject", :ack! => nil)}
-      before { job.tomqueue_work = work_object}
-
-      it "should call ack! on the work object after the job has been invoked" do
-        payload.should_receive(:perform).ordered
-        work_object.should_receive(:ack!).ordered
-        job.invoke_job
-      end
-
-      it "should call ack! on the work object if an exception is raised" do
-        payload.should_receive(:perform).ordered.and_raise(RuntimeError, "OMG!!!11")
-        work_object.should_receive(:ack!).ordered
-        lambda {
-          job.invoke_job
-        }.should raise_exception(RuntimeError, "OMG!!!11")
-      end
-    end
   end
 
 

--- a/spec/tom_queue/helper.rb
+++ b/spec/tom_queue/helper.rb
@@ -75,3 +75,9 @@ RSpec.configure do |r|
     end
   end
 end
+
+def unacked_message_count(priority)
+  queue_name = Delayed::Job.tomqueue_manager.queues[priority].name
+  response = RestClient.get("http://guest:guest@localhost:15672/api/queues/test/#{queue_name}", :accept => :json)
+  JSON.parse(response)["messages_unacknowledged"]
+end


### PR DESCRIPTION
There is a race condition where a job may be acked and then not destroyed (e.g. if the process is killed).
Flip this around so we destroy the job first. We need a plugin to ack the job after a perform in order
to do it at the right time.