### PR TITLE
Only ack on destroy if tomqueue is active

### DIFF
--- a/lib/tom_queue/delayed_job/ack_work_plugin.rb
+++ b/lib/tom_queue/delayed_job/ack_work_plugin.rb
@@ -5,7 +5,7 @@ module TomQueue
     class AckWorkPlugin < Delayed::Plugin
       callbacks do |lifecycle|
         lifecycle.after(:perform) do |_, job|
-          job.tomqueue_work.ack! if job.tomqueue_work
+          job.tomqueue_work.ack! if job.respond_to?(:tomqueue_work) && job.tomqueue_work
         end
       end
 


### PR DESCRIPTION
If tomqueue isn't enabled, this throws a wobbly without checking if it should be run