### PR TITLE
Remove Delayed Job dependency for publishing

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ gem 'sqlite3'
 gem 'mysql2', '~> 0.3.13'
 
 group :development, :test do
-  gem "pry"
+  gem "pry-byebug"
 end
 
 gemspec

--- a/lib/tom_queue.rb
+++ b/lib/tom_queue.rb
@@ -1,5 +1,5 @@
 # This is a bit of a library-in-a-library, for the time being
-# 
+#
 # This module manages the interaction with AMQP, handling publishing of
 # work messages, scheduling of work off the AMQP queue, etc.
 #
@@ -9,10 +9,10 @@
 #
 module TomQueue
   require 'tom_queue/logging_helper'
-  
+
   require 'tom_queue/queue_manager'
   require 'tom_queue/work'
-  
+
   require 'tom_queue/deferred_work_set'
   require 'tom_queue/deferred_work_manager'
 
@@ -26,7 +26,7 @@ module TomQueue
   end
   # Public: Returns the current bunny instance
   #
-  # Returns whatever was passed to TomQueue.bunny = 
+  # Returns whatever was passed to TomQueue.bunny =
   def bunny
     defined?(@@bunny) && @@bunny
   end
@@ -40,11 +40,19 @@ module TomQueue
   end
   module_function :default_prefix=, :default_prefix
 
+  # Public: Allow a hash of config options to be passed to TomQueue
+  def config=(config)
+    @@config = config
+  end
+  def config
+    @@config ||= {}
+  end
+  module_function :config=, :config
 
   # Public: Set an object to receive notifications if an internal exception
   # is caught and handled.
   #
-  # IT should be an object that responds to #notify(exception) and should be 
+  # IT should be an object that responds to #notify(exception) and should be
   # thread safe as reported exceptions will be from background threads crashing.
   #
   class << self

--- a/lib/tom_queue.rb
+++ b/lib/tom_queue.rb
@@ -20,6 +20,9 @@ module TomQueue
 
   require 'tom_queue/sorted_array'
 
+  require 'tom_queue/stack'
+  require 'tom_queue/enqueue'
+
   # Public: Sets the bunny instance to use for new QueueManager objects
   def bunny=(new_bunny)
     @@bunny = new_bunny

--- a/lib/tom_queue/delayed_job.rb
+++ b/lib/tom_queue/delayed_job.rb
@@ -16,6 +16,10 @@ module TomQueue
     def apply_hook!
       Delayed::Worker.sleep_delay = 0
       Delayed::Worker.backend = TomQueue::DelayedJob::Job
+
+      if TomQueue.config[:override_enqueue]
+        Delayed::Job.send(:extend, TomQueue::DelayedJob::ClassMethods)
+      end
     end
     module_function :apply_hook!
 

--- a/lib/tom_queue/delayed_job/external_messages.rb
+++ b/lib/tom_queue/delayed_job/external_messages.rb
@@ -20,14 +20,13 @@ module TomQueue
 
           # Look for a matching source exchange!
           klass = TomQueue::DelayedJob.handlers.find { |klass| klass.claim_work?(work) }
-          
           if klass
             debug { "Resolved external handler #{klass} for message. Calling the init block." }
 
             block = klass.claim_work?(work)
 
             job = block.call(work)
-            if job.is_a?(Delayed::Job)
+            if job.is_a?(Delayed::Job) || job.is_a?(TomQueue::Persistence::Model)
               debug { "Got a job #{job.id}"}
               job
             else

--- a/lib/tom_queue/delayed_job/job.rb
+++ b/lib/tom_queue/delayed_job/job.rb
@@ -1,5 +1,5 @@
 require 'active_support/concern'
-require "tom_queue/delayed_job/job/overrides"
+require "tom_queue/delayed_job/job/class_methods"
 
 module TomQueue
   module DelayedJob

--- a/lib/tom_queue/delayed_job/job.rb
+++ b/lib/tom_queue/delayed_job/job.rb
@@ -1,4 +1,5 @@
 require 'active_support/concern'
+require "tom_queue/delayed_job/job/overrides"
 
 module TomQueue
   module DelayedJob

--- a/lib/tom_queue/delayed_job/job/class_methods.rb
+++ b/lib/tom_queue/delayed_job/job/class_methods.rb
@@ -8,9 +8,7 @@ module TomQueue
       # Allows us to skip DJ for enqueuing new work
       #
       def enqueue(*args)
-        # attributes = TomQueue::DelayedJob::JobPreparer.new(*args).prepare
-        # puts TomQueue::Persistence::Model.create!(attributes)
-        # super
+        TomQueue.enqueue(*args)
       end
     end
   end

--- a/lib/tom_queue/delayed_job/job/class_methods.rb
+++ b/lib/tom_queue/delayed_job/job/class_methods.rb
@@ -7,8 +7,11 @@ module TomQueue
       # Public: Override Delayed::Job.enqueue
       # Allows us to skip DJ for enqueuing new work
       #
+      # Returns a persisted model instance
       def enqueue(*args)
-        TomQueue.enqueue(*args)
+        work, options = TomQueue::Job::Preparer.new(*args).prepare
+        # first return value from the stack is the persisted instance
+        TomQueue.enqueue(work, options)[0]
       end
     end
   end

--- a/lib/tom_queue/delayed_job/job/class_methods.rb
+++ b/lib/tom_queue/delayed_job/job/class_methods.rb
@@ -1,14 +1,17 @@
+require "tom_queue/job/preparer"
+require "tom_queue/persistence/model"
+
 module TomQueue
   module DelayedJob
     module ClassMethods
+      # Public: Override Delayed::Job.enqueue
+      # Allows us to skip DJ for enqueuing new work
+      #
       def enqueue(*args)
-        # TODO: Hook in here and don't call DJ's enqueue method
-        super
+        # attributes = TomQueue::DelayedJob::JobPreparer.new(*args).prepare
+        # puts TomQueue::Persistence::Model.create!(attributes)
+        # super
       end
     end
   end
-end
-
-if defined?(Delayed) && defined?(Delayed::Job)
-  Delayed::Job.send(:extend, TomQueue::DelayedJob::ClassMethods)
 end

--- a/lib/tom_queue/delayed_job/job/class_methods.rb
+++ b/lib/tom_queue/delayed_job/job/class_methods.rb
@@ -1,0 +1,14 @@
+module TomQueue
+  module DelayedJob
+    module ClassMethods
+      def enqueue(*args)
+        # TODO: Hook in here and don't call DJ's enqueue method
+        super
+      end
+    end
+  end
+end
+
+if defined?(Delayed) && defined?(Delayed::Job)
+  Delayed::Job.send(:extend, TomQueue::DelayedJob::ClassMethods)
+end

--- a/lib/tom_queue/enqueue.rb
+++ b/lib/tom_queue/enqueue.rb
@@ -5,17 +5,20 @@ require "tom_queue/layers/publish"
 
 module TomQueue
   class Enqueue < TomQueue::Stack
-    insert Layers::Publish
-    insert Layers::Persist
-    insert Layers::Log
+    use Layers::Log
+    use Layers::Persist
+    use Layers::Publish
   end
 
+  # Public: Intended to be a direct replacement for Delayed::Job.enqueue, this
+  # takes the arguments, separates them into work and queue options, and passes them
+  # into the enqueue call stack
+  #
+  # Returns [work, options]
   def enqueue(*args)
     work, options = Job::Preparer.new(*args).prepare
-    Enqueue.stack.call(work, options)
+    Enqueue.call(work, options)
   end
 
   module_function :enqueue
 end
-
-binding.pry; ""

--- a/lib/tom_queue/enqueue.rb
+++ b/lib/tom_queue/enqueue.rb
@@ -1,0 +1,21 @@
+require "tom_queue/job/preparer"
+require "tom_queue/layers/log"
+require "tom_queue/layers/persist"
+require "tom_queue/layers/publish"
+
+module TomQueue
+  class Enqueue < TomQueue::Stack
+    insert Layers::Publish
+    insert Layers::Persist
+    insert Layers::Log
+  end
+
+  def enqueue(*args)
+    work, options = Job::Preparer.new(*args).prepare
+    Enqueue.stack.call(work, options)
+  end
+
+  module_function :enqueue
+end
+
+binding.pry; ""

--- a/lib/tom_queue/enqueue.rb
+++ b/lib/tom_queue/enqueue.rb
@@ -5,18 +5,17 @@ require "tom_queue/layers/publish"
 
 module TomQueue
   class Enqueue < TomQueue::Stack
-    use Layers::Log
     use Layers::Persist
     use Layers::Publish
   end
 
-  # Public: Intended to be a direct replacement for Delayed::Job.enqueue, this
-  # takes the arguments, separates them into work and queue options, and passes them
-  # into the enqueue call stack
+  # Public: Push a work unit into the queue stack
+  #
+  # work - the work unit being enqueued
+  # options - Hash of options defining how the job should be run
   #
   # Returns [work, options]
-  def enqueue(*args)
-    work, options = Job::Preparer.new(*args).prepare
+  def enqueue(work, options = {})
     Enqueue.call(work, options)
   end
 

--- a/lib/tom_queue/external_consumer.rb
+++ b/lib/tom_queue/external_consumer.rb
@@ -94,9 +94,17 @@ module TomQueue
 
       private
 
+      def tomqueue_manager
+        if TomQueue.config[:override_enqueue]
+          TomQueue::Layers::Publish.queue_manager
+        else
+          Delayed::Job.tomqueue_manager
+        end
+      end
+
       # Internal: set up an exchange for publishing messages to
       def exchange
-        Delayed::Job.tomqueue_manager.channel.exchange(@name,
+        tomqueue_manager.channel.exchange(@name,
           :type => @type,
           :auto_delete => @auto_delete,
           :durable => @durable

--- a/lib/tom_queue/job/preparer.rb
+++ b/lib/tom_queue/job/preparer.rb
@@ -1,12 +1,8 @@
+require "active_support/core_ext/array/extract_options"
+
 module TomQueue
   module Job
     class Preparer
-      # Mostly taken from https://github.com/collectiveidea/delayed_job/blob/master/lib/delayed/backend/job_preparer.rb
-
-      # TODO: Allow these to be set from TomQueue.config
-      DEFAULT_QUEUE_NAME = "normal"
-      DEFAULT_PRIORITY = 0
-
       attr_reader :options, :args
 
       def initialize(*args)
@@ -15,41 +11,20 @@ module TomQueue
       end
 
       def prepare
-        set_payload
-        set_queue_name
-        set_priority
-        handle_deprecation
-        options
+        [work, prepare_options]
       end
 
-    private
+      private
 
-      def set_payload
-        options[:payload_object] ||= args.shift
+      def work
+        options[:payload_object] || args.shift
       end
 
-      def set_queue_name
-        if options[:queue].nil? && options[:payload_object].respond_to?(:queue_name)
-          options[:queue] = options[:payload_object].queue_name
-        else
-          options[:queue] ||= DEFAULT_QUEUE_NAME
-        end
-      end
-
-      def set_priority
-        options[:priority] ||= DEFAULT_PRIORITY
-      end
-
-      def handle_deprecation
-        if args.size > 0
-          warn '[DEPRECATION] Passing multiple arguments to `#enqueue` is deprecated. Pass a hash with :priority and :run_at.'
-          options[:priority] = args.first || options[:priority]
-          options[:run_at]   = args[1]
-        end
-
-        unless options[:payload_object].respond_to?(:perform)
-          raise ArgumentError, 'Cannot enqueue items which do not respond to perform'
-        end
+      def prepare_options
+        {
+          run_at: Time.now,
+          priority: 0
+        }.merge(options)
       end
     end
   end

--- a/lib/tom_queue/job/preparer.rb
+++ b/lib/tom_queue/job/preparer.rb
@@ -24,13 +24,13 @@ module TomQueue
         end
 
         if args.size > 0
-          warn '[DEPRECATION] Passing multiple arguments to `#enqueue` is deprecated. Pass a hash with :priority and :run_at.'
+          TomQueue.logger.warn "[DEPRECATION] Passing multiple arguments to `#enqueue` is deprecated. Pass a hash with :priority and :run_at."
           options[:priority] = args.first || options[:priority]
           options[:run_at]   = args[1]
         end
 
         unless work.respond_to?(:perform)
-          raise ArgumentError, 'Cannot enqueue items which do not respond to perform'
+          raise ArgumentError, "Cannot enqueue items which do not respond to perform"
         end
 
         [work, options]

--- a/lib/tom_queue/job/preparer.rb
+++ b/lib/tom_queue/job/preparer.rb
@@ -1,0 +1,56 @@
+module TomQueue
+  module Job
+    class Preparer
+      # Mostly taken from https://github.com/collectiveidea/delayed_job/blob/master/lib/delayed/backend/job_preparer.rb
+
+      # TODO: Allow these to be set from TomQueue.config
+      DEFAULT_QUEUE_NAME = "normal"
+      DEFAULT_PRIORITY = 0
+
+      attr_reader :options, :args
+
+      def initialize(*args)
+        @options = args.extract_options!.dup
+        @args = args
+      end
+
+      def prepare
+        set_payload
+        set_queue_name
+        set_priority
+        handle_deprecation
+        options
+      end
+
+    private
+
+      def set_payload
+        options[:payload_object] ||= args.shift
+      end
+
+      def set_queue_name
+        if options[:queue].nil? && options[:payload_object].respond_to?(:queue_name)
+          options[:queue] = options[:payload_object].queue_name
+        else
+          options[:queue] ||= DEFAULT_QUEUE_NAME
+        end
+      end
+
+      def set_priority
+        options[:priority] ||= DEFAULT_PRIORITY
+      end
+
+      def handle_deprecation
+        if args.size > 0
+          warn '[DEPRECATION] Passing multiple arguments to `#enqueue` is deprecated. Pass a hash with :priority and :run_at.'
+          options[:priority] = args.first || options[:priority]
+          options[:run_at]   = args[1]
+        end
+
+        unless options[:payload_object].respond_to?(:perform)
+          raise ArgumentError, 'Cannot enqueue items which do not respond to perform'
+        end
+      end
+    end
+  end
+end

--- a/lib/tom_queue/layers/log.rb
+++ b/lib/tom_queue/layers/log.rb
@@ -4,11 +4,13 @@ module TomQueue
   module Layers
     class Log < TomQueue::Stack::Layer
       def call(work, options)
-        puts "Enqueuing #{work}"
-        execution_time = Benchmark.realtime do
-          chain.call(work, options)
-        end
-        puts "Completed in %.4fs" % execution_time
+        chain.call(work, options.merge(logger: logger))
+      end
+
+      private
+
+      def logger
+        @logger ||= (TomQueue.logger || Logger.new(STDOUT))
       end
     end
   end

--- a/lib/tom_queue/layers/log.rb
+++ b/lib/tom_queue/layers/log.rb
@@ -1,0 +1,15 @@
+module TomQueue
+  module Layers
+    class Log < TomQueue::Stack::Layer
+      def initialize(*args)
+        # @logger = TomQueue.logger
+        super
+      end
+
+      def call(work, options)
+        puts "Log"
+        @chain.call(work, options)
+      end
+    end
+  end
+end

--- a/lib/tom_queue/layers/log.rb
+++ b/lib/tom_queue/layers/log.rb
@@ -1,14 +1,14 @@
+require "benchmark"
+
 module TomQueue
   module Layers
     class Log < TomQueue::Stack::Layer
-      def initialize(*args)
-        # @logger = TomQueue.logger
-        super
-      end
-
       def call(work, options)
-        puts "Log"
-        @chain.call(work, options)
+        puts "Enqueuing #{work}"
+        execution_time = Benchmark.realtime do
+          chain.call(work, options)
+        end
+        puts "Completed in %.4fs" % execution_time
       end
     end
   end

--- a/lib/tom_queue/layers/persist.rb
+++ b/lib/tom_queue/layers/persist.rb
@@ -1,9 +1,57 @@
 module TomQueue
   module Layers
     class Persist < TomQueue::Stack::Layer
+      # Public: For Delayed Job compatible work units, persist them to the
+      # database and substitutes the work for the now persisted job
+      #
+      # work - the work unit being enqueued
+      # options - Hash of options defining how the job should be run
+      #
+      # Returns modified [work, options]
       def call(work, options)
-        puts "Persist"
-        chain.call(work, options)
+        if delayed_job?(work)
+          job = build(work, options).tap do |job|
+            # Run the work unit's :enqueue lifecycle hook if present
+            work.enqueue(job) if work.respond_to?(:enqueue)
+          end
+          job.save!
+          chain.call(job, options)
+        else
+          chain.call(work, options.merge(job: job))
+        end
+      end
+
+      private
+
+      # Private: Is this a Delayed Job compatible work unit?
+      #
+      # work - the work unit being enqueued
+      #
+      # Returns boolean
+      def delayed_job?(work)
+        work.respond_to?(:perform)
+      end
+
+      # Private: Build the Delayed Job compatible persistence model
+      #
+      # work - the work unit being enqueued
+      # options - Hash of options defining how the job should be run
+      #
+      # Returns a non-persisted model instance
+      def build(work, options)
+        TomQueue::Persistence::Model.new(attributes(work, options))
+      end
+
+      # Private: Build attributes to be persisted on the model
+      #
+      # work - the work unit being enqueued
+      # options - Hash of options defining how the job should be run
+      #
+      # Returns a Hash
+      def attributes(work, options)
+        options.with_indifferent_access.slice(*TomQueue::Persistence::Model::ENQUEUE_ATTRIBUTES).tap do |attrs|
+          attrs[:handler] ||= work.to_yaml
+        end
       end
     end
   end

--- a/lib/tom_queue/layers/persist.rb
+++ b/lib/tom_queue/layers/persist.rb
@@ -1,0 +1,10 @@
+module TomQueue
+  module Layers
+    class Persist < TomQueue::Stack::Layer
+      def call(work, options)
+        puts "Persist"
+        @chain.call(work, options)
+      end
+    end
+  end
+end

--- a/lib/tom_queue/layers/persist.rb
+++ b/lib/tom_queue/layers/persist.rb
@@ -1,6 +1,8 @@
 module TomQueue
   module Layers
     class Persist < TomQueue::Stack::Layer
+      include LoggingHelper
+
       # Public: For Delayed Job compatible work units, persist them to the
       # database and substitutes the work for the now persisted job
       #
@@ -15,6 +17,8 @@ module TomQueue
             work.enqueue(j) if work.respond_to?(:enqueue)
           end
           job.save!
+          debug "[#{self.class.name}] Created job #{job.id}"
+
           chain.call(job, options)
         else
           chain.call(work, options.merge(job: job))

--- a/lib/tom_queue/layers/persist.rb
+++ b/lib/tom_queue/layers/persist.rb
@@ -39,7 +39,9 @@ module TomQueue
       #
       # Returns a non-persisted model instance
       def build(work, options)
-        TomQueue::Persistence::Model.new(attributes(work, options))
+        TomQueue::Persistence::Model.new(attributes(work, options)).tap do |j|
+          j.payload_object = work
+        end
       end
 
       # Private: Build attributes to be persisted on the model

--- a/lib/tom_queue/layers/persist.rb
+++ b/lib/tom_queue/layers/persist.rb
@@ -3,7 +3,7 @@ module TomQueue
     class Persist < TomQueue::Stack::Layer
       def call(work, options)
         puts "Persist"
-        @chain.call(work, options)
+        chain.call(work, options)
       end
     end
   end

--- a/lib/tom_queue/layers/persist.rb
+++ b/lib/tom_queue/layers/persist.rb
@@ -10,9 +10,9 @@ module TomQueue
       # Returns modified [work, options]
       def call(work, options)
         if delayed_job?(work)
-          job = build(work, options).tap do |job|
+          job = build(work, options).tap do |j|
             # Run the work unit's :enqueue lifecycle hook if present
-            work.enqueue(job) if work.respond_to?(:enqueue)
+            work.enqueue(j) if work.respond_to?(:enqueue)
           end
           job.save!
           chain.call(job, options)

--- a/lib/tom_queue/layers/publish.rb
+++ b/lib/tom_queue/layers/publish.rb
@@ -3,7 +3,7 @@ module TomQueue
     class Publish < TomQueue::Stack::Layer
       def call(work, options)
         puts "Publish"
-        @chain.call(work, options)
+        chain.call(work, options)
       end
     end
   end

--- a/lib/tom_queue/layers/publish.rb
+++ b/lib/tom_queue/layers/publish.rb
@@ -1,0 +1,10 @@
+module TomQueue
+  module Layers
+    class Publish < TomQueue::Stack::Layer
+      def call(work, options)
+        puts "Publish"
+        @chain.call(work, options)
+      end
+    end
+  end
+end

--- a/lib/tom_queue/layers/publish.rb
+++ b/lib/tom_queue/layers/publish.rb
@@ -9,7 +9,7 @@ module TomQueue
       # Returns modified [work, options]
       def call(work, options)
         if work.is_a?(TomQueue::Persistence::Model)
-          publish_delayed_job(work, options)
+          publish_delayed_job(work)
         else
           # TODO: Implement non DJ work
           raise "Unknown work type"
@@ -32,7 +32,7 @@ module TomQueue
       # options - a Hash of options describing the work
       #
       # Returns nothing
-      def publish_delayed_job(job, options)
+      def publish_delayed_job(job)
         raise ArgumentError, "cannot publish an unsaved Delayed::Job object" if job.new_record?
 
         payload = JSON.dump({

--- a/lib/tom_queue/layers/publish.rb
+++ b/lib/tom_queue/layers/publish.rb
@@ -27,7 +27,7 @@ module TomQueue
       #
       # Returns a memoized TomQueue::QueueManager
       def self.queue_manager
-        @tomqueue_manager ||= TomQueue::QueueManager.new.tap do |manager|
+        @@tomqueue_manager ||= TomQueue::QueueManager.new.tap do |manager|
           setup_external_handler(manager)
         end
       end

--- a/lib/tom_queue/layers/publish.rb
+++ b/lib/tom_queue/layers/publish.rb
@@ -42,7 +42,7 @@ module TomQueue
       def publish_delayed_job(job)
         raise ArgumentError, "cannot publish an unsaved Delayed::Job object" if job.new_record?
 
-        debug "[tomqueue_publish] Pushing notification for #{job.id} to run in #{(job.run_at - Time.now).round(2)}"
+        debug "[#{self.class.name}] Pushing notification for #{job.id} to run in #{(job.run_at - Time.now).round(2)}"
 
         payload = JSON.dump({
           "delayed_job_id"         => job.id,

--- a/lib/tom_queue/layers/publish.rb
+++ b/lib/tom_queue/layers/publish.rb
@@ -3,6 +3,7 @@ require "tom_queue/delayed_job/external_messages"
 module TomQueue
   module Layers
     class Publish < TomQueue::Stack::Layer
+      include LoggingHelper
       include TomQueue::DelayedJob::ExternalMessages
 
       # Public: Push the work unit to the queue manager
@@ -40,6 +41,8 @@ module TomQueue
       # Returns nothing
       def publish_delayed_job(job)
         raise ArgumentError, "cannot publish an unsaved Delayed::Job object" if job.new_record?
+
+        debug "[tomqueue_publish] Pushing notification for #{job.id} to run in #{(job.run_at - Time.now).round(2)}"
 
         payload = JSON.dump({
           "delayed_job_id"         => job.id,

--- a/lib/tom_queue/layers/publish.rb
+++ b/lib/tom_queue/layers/publish.rb
@@ -1,9 +1,48 @@
 module TomQueue
   module Layers
     class Publish < TomQueue::Stack::Layer
+      # Public: Push the work unit to the queue manager
+      #
+      # work - the work unit being enqueued
+      # options - Hash of options defining how the job should be run
+      #
+      # Returns modified [work, options]
       def call(work, options)
-        puts "Publish"
+        if work.is_a?(TomQueue::Persistence::Model)
+          publish_delayed_job(work, options)
+        else
+          # TODO: Implement non DJ work
+          raise "Unknown work type"
+        end
         chain.call(work, options)
+      end
+
+      private
+
+      # Private: The QueueManager instance
+      #
+      # Returns a memoized TomQueue::QueueManager
+      def queue_manager
+        @tomqueue_manager ||= TomQueue::QueueManager.new
+      end
+
+      # Private: Publish the delayed job to the queue manager
+      #
+      # job - a persistence model instance
+      # options - a Hash of options describing the work
+      #
+      # Returns nothing
+      def publish_delayed_job(job, options)
+        raise ArgumentError, "cannot publish an unsaved Delayed::Job object" if job.new_record?
+
+        payload = JSON.dump({
+          "delayed_job_id"         => job.id,
+          "delayed_job_digest"     => job.digest,
+          "delayed_job_updated_at" => job.updated_at.iso8601(0)
+        })
+
+        priority = TomQueue::DelayedJob.priority_map.fetch(job.priority, TomQueue::NORMAL_PRIORITY)
+        queue_manager.publish(payload, run_at: job.run_at, priority: priority)
       end
     end
   end

--- a/lib/tom_queue/persistence/model.rb
+++ b/lib/tom_queue/persistence/model.rb
@@ -20,6 +20,14 @@ module TomQueue
         end.to_s
         Digest::MD5.hexdigest(digest_string)
       end
+
+      # Public: We never want to publish this job using callbacks, and because
+      # we inherit from Delayed::Job we need to prevent this for now.
+      #
+      # Returns boolean...
+      def skip_publish
+        true
+      end
     end
   end
 end

--- a/lib/tom_queue/persistence/model.rb
+++ b/lib/tom_queue/persistence/model.rb
@@ -1,9 +1,24 @@
 module TomQueue
   module Persistence
     class Model < ActiveRecord::Base
+      ENQUEUE_ATTRIBUTES = %i{priority handler run_at queue}
+
       self.table_name = :delayed_jobs
 
       before_save :set_default_run_at
+
+      # Public: Calculate a hexdigest of the attributes
+      #
+      # This is used to detect if the received message is stale, as it's
+      # sent as part of the AMQP payload and then re-calculated when the
+      # worker is about to run the job.
+      #
+      # Returns a string
+      BROKEN_DIGEST_CLASSES = [DateTime, Time, ActiveSupport::TimeWithZone]
+      def digest
+        digest_string = self.attributes.map { |k,v| BROKEN_DIGEST_CLASSES.include?(v.class) ? [k,v.to_i] : [k,v.to_s] }.to_s
+        Digest::MD5.hexdigest(digest_string)
+      end
 
       private
 

--- a/lib/tom_queue/persistence/model.rb
+++ b/lib/tom_queue/persistence/model.rb
@@ -2,7 +2,7 @@ module TomQueue
   module Persistence
     # TODO: Remove the inheritance once the link to DJ has been killed
     class Model < ::Delayed::Job
-      ENQUEUE_ATTRIBUTES = %i{priority handler run_at queue}
+      ENQUEUE_ATTRIBUTES = %i{priority run_at queue}
 
       self.table_name = :delayed_jobs
 

--- a/lib/tom_queue/persistence/model.rb
+++ b/lib/tom_queue/persistence/model.rb
@@ -16,7 +16,9 @@ module TomQueue
       # Returns a string
       BROKEN_DIGEST_CLASSES = [DateTime, Time, ActiveSupport::TimeWithZone]
       def digest
-        digest_string = self.attributes.map { |k,v| BROKEN_DIGEST_CLASSES.include?(v.class) ? [k,v.to_i] : [k,v.to_s] }.to_s
+        digest_string = attributes.map do |k,v|
+          BROKEN_DIGEST_CLASSES.include?(v.class) ? [k,v.to_i] : [k,v.to_s] }.to_s
+        end
         Digest::MD5.hexdigest(digest_string)
       end
 

--- a/lib/tom_queue/persistence/model.rb
+++ b/lib/tom_queue/persistence/model.rb
@@ -17,9 +17,13 @@ module TomQueue
       BROKEN_DIGEST_CLASSES = [DateTime, Time, ActiveSupport::TimeWithZone]
       def digest
         digest_string = attributes.map do |k,v|
-          BROKEN_DIGEST_CLASSES.include?(v.class) ? [k,v.to_i] : [k,v.to_s] }.to_s
-        end
+          BROKEN_DIGEST_CLASSES.include?(v.class) ? [k,v.to_i] : [k,v.to_s]
+        end.to_s
         Digest::MD5.hexdigest(digest_string)
+      end
+
+      def failed?
+        failed_at.present?
       end
 
       private

--- a/lib/tom_queue/persistence/model.rb
+++ b/lib/tom_queue/persistence/model.rb
@@ -1,0 +1,28 @@
+module TomQueue
+  module Persistence
+    class Model < ActiveRecord::Base
+      self.table_name = :delayed_jobs
+
+      before_save :set_default_run_at
+
+      private
+
+      def set_default_run_at
+        self.run_at ||= self.class.db_time_now
+      end
+
+      # Get the current time (GMT or local depending on DB)
+      # Note: This does not ping the DB to get the time, so all your clients
+      # must have syncronized clocks.
+      def self.db_time_now
+        if Time.zone
+          Time.zone.now
+        elsif ::ActiveRecord::Base.default_timezone == :utc
+          Time.now.utc
+        else
+          Time.now
+        end
+      end
+    end
+  end
+end

--- a/lib/tom_queue/persistence/model.rb
+++ b/lib/tom_queue/persistence/model.rb
@@ -1,11 +1,10 @@
 module TomQueue
   module Persistence
-    class Model < ActiveRecord::Base
+    # TODO: Remove the inheritance once the link to DJ has been killed
+    class Model < ::Delayed::Job
       ENQUEUE_ATTRIBUTES = %i{priority handler run_at queue}
 
       self.table_name = :delayed_jobs
-
-      before_save :set_default_run_at
 
       # Public: Calculate a hexdigest of the attributes
       #
@@ -20,29 +19,6 @@ module TomQueue
           BROKEN_DIGEST_CLASSES.include?(v.class) ? [k,v.to_i] : [k,v.to_s]
         end.to_s
         Digest::MD5.hexdigest(digest_string)
-      end
-
-      def failed?
-        failed_at.present?
-      end
-
-      private
-
-      def set_default_run_at
-        self.run_at ||= self.class.db_time_now
-      end
-
-      # Get the current time (GMT or local depending on DB)
-      # Note: This does not ping the DB to get the time, so all your clients
-      # must have syncronized clocks.
-      def self.db_time_now
-        if Time.zone
-          Time.zone.now
-        elsif ::ActiveRecord::Base.default_timezone == :utc
-          Time.now.utc
-        else
-          Time.now
-        end
       end
     end
   end

--- a/lib/tom_queue/stack.rb
+++ b/lib/tom_queue/stack.rb
@@ -57,7 +57,7 @@ module TomQueue
       #
       # Returns modified [work, options]
       def call(work, options)
-        return [work, options]
+        [work, options]
       end
 
       # Public: Adds a new layer if this layer is at the bottom of the stack,

--- a/lib/tom_queue/stack.rb
+++ b/lib/tom_queue/stack.rb
@@ -1,27 +1,85 @@
 module TomQueue
   class Stack
+    TERMINATOR = lambda { |work, options| [work, options] }
+
+    # Public: Insert a middleware layer at the beginning of the stack.
+    # middleware - a descendant of TomQueue::Stack::Layer
+    # options - a hash of options to use when instantiating the middleware
+    #
+    # Returns nothing
     def self.insert(middleware, options = {})
-      @@stack = middleware.new(stack, options)
+      @stack = middleware.new(stack, options)
     end
 
+    # Public: Append a middleware layer to the end of the stack.
+    # middleware - a descendant of TomQueue::Stack::Layer
+    # options - a hash of options to use when instantiating the middleware
+    #
+    # Returns nothing
+    def self.use(middleware, options = {})
+      if stack
+        stack.append(middleware, options)
+      else
+        @stack = middleware.new(nil, options)
+      end
+    end
+
+    # Public: Entry point to call the stack
+    # work - the object being worked on (Job class instance usually)
+    # options - Hash of options defining how the job should be run
+    #
+    # Returns modified [work, options]
+    def self.call(work, options)
+      (stack || TERMINATOR).call(work, options)
+    end
+
+    # Internal: The class' middleware stack
+    #
+    # Returns a TomQueue::Stack::Layer instance or nil
     def self.stack
-      @@stack ||= Terminator.new(nil, nil)
+      @stack ||= nil
     end
 
     class Layer
-      def initialize(chain, options = {})
+      attr_accessor :config
+
+      def initialize(chain = nil, config = {})
         @chain = chain
-        @options = options
+        @config = config
       end
 
-      def call(job)
-        raise NotImplementedError, "TomQueue Stack Layers must implement their own call method"
+      # Public: Execute the middleware layer.
+      # Subclasses should _usually_ chain.call(work, options) unless they want to
+      # stop execution of the stack in which case they should just return
+      #
+      # work - the object being worked on (Job class instance usually)
+      # options - Hash of options defining how the job should be run
+      #
+      # Returns modified [work, options]
+      def call(work, options)
+        return [work, options]
       end
-    end
 
-    class Terminator < Layer
-      def call(*args)
-        return *args
+      # Public: Replaces the terminator with a new middleware, or passes it
+      # to the next layer in the chain
+      # middleware - a descendant of TomQueue::Stack::Layer
+      # options - a hash of options to use when instantiating the middleware
+      #
+      # Returns nothing
+      def append(middleware, options = {})
+        if @chain.nil?
+          @chain = middleware.new(nil, options)
+        else
+          @chain.append(middleware, options)
+        end
+      end
+
+      # Internal: Return the next layer in the stack. If we're at the bottom layer
+      # return the TERMINATOR reflector to begin the journey back up the layers
+      #
+      # Returns a Layer or Proc instance
+      def chain
+        @chain || TomQueue::Stack::TERMINATOR
       end
     end
   end

--- a/lib/tom_queue/stack.rb
+++ b/lib/tom_queue/stack.rb
@@ -2,25 +2,25 @@ module TomQueue
   class Stack
     TERMINATOR = lambda { |work, options| [work, options] }
 
-    # Public: Insert a middleware layer at the beginning of the stack.
-    # middleware - a descendant of TomQueue::Stack::Layer
-    # options - a hash of options to use when instantiating the middleware
+    # Public: Insert a layer at the beginning of the stack.
+    # layer - a descendant of TomQueue::Stack::Layer
+    # options - a hash of options to use when instantiating the layer
     #
     # Returns nothing
-    def self.insert(middleware, options = {})
-      @stack = middleware.new(stack, options)
+    def self.insert(layer, options = {})
+      @stack = layer.new(stack, options)
     end
 
-    # Public: Append a middleware layer to the end of the stack.
-    # middleware - a descendant of TomQueue::Stack::Layer
-    # options - a hash of options to use when instantiating the middleware
+    # Public: Append a layer to the end of the stack.
+    # layer - a descendant of TomQueue::Stack::Layer
+    # options - a hash of options to use when instantiating the layer
     #
     # Returns nothing
-    def self.use(middleware, options = {})
+    def self.use(layer, options = {})
       if stack
-        stack.append(middleware, options)
+        stack.append(layer, options)
       else
-        @stack = middleware.new(nil, options)
+        @stack = layer.new(nil, options)
       end
     end
 
@@ -33,7 +33,7 @@ module TomQueue
       (stack || TERMINATOR).call(work, options)
     end
 
-    # Internal: The class' middleware stack
+    # Internal: The class' layer stack
     #
     # Returns a TomQueue::Stack::Layer instance or nil
     def self.stack
@@ -48,7 +48,7 @@ module TomQueue
         @config = config
       end
 
-      # Public: Execute the middleware layer.
+      # Public: Execute the stack
       # Subclasses should _usually_ chain.call(work, options) unless they want to
       # stop execution of the stack in which case they should just return
       #
@@ -60,17 +60,18 @@ module TomQueue
         return [work, options]
       end
 
-      # Public: Replaces the terminator with a new middleware, or passes it
-      # to the next layer in the chain
-      # middleware - a descendant of TomQueue::Stack::Layer
-      # options - a hash of options to use when instantiating the middleware
+      # Public: Adds a new layer if this layer is at the bottom of the stack,
+      # or passes it to the next layer in the chain
+      #
+      # layer - a descendant of TomQueue::Stack::Layer
+      # options - a hash of options to use when instantiating the layer
       #
       # Returns nothing
-      def append(middleware, options = {})
+      def append(layer, options = {})
         if @chain.nil?
-          @chain = middleware.new(nil, options)
+          @chain = layer.new(nil, options)
         else
-          @chain.append(middleware, options)
+          @chain.append(layer, options)
         end
       end
 

--- a/lib/tom_queue/stack.rb
+++ b/lib/tom_queue/stack.rb
@@ -1,0 +1,28 @@
+module TomQueue
+  class Stack
+    def self.insert(middleware, options = {})
+      @@stack = middleware.new(stack, options)
+    end
+
+    def self.stack
+      @@stack ||= Terminator.new(nil, nil)
+    end
+
+    class Layer
+      def initialize(chain, options = {})
+        @chain = chain
+        @options = options
+      end
+
+      def call(job)
+        raise NotImplementedError, "TomQueue Stack Layers must implement their own call method"
+      end
+    end
+
+    class Terminator < Layer
+      def call(*args)
+        return *args
+      end
+    end
+  end
+end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -1,5 +1,6 @@
 require 'logger'
 require 'rspec'
+require 'pry-byebug'
 
 begin
   require 'protected_attributes'

--- a/spec/tom_queue/helper.rb
+++ b/spec/tom_queue/helper.rb
@@ -35,7 +35,7 @@ RSpec.configure do |r|
   # Make sure all tests see the same Bunny instance
   r.before do |test|
     TomQueue.bunny = TheBunny
-    TomQueue.config[:override_enqueue] = ENV["NEUTER_DJ"] || false
+    TomQueue.config[:override_enqueue] = ENV["NEUTER_DJ"] == "true"
   end
 
   r.around do |test|

--- a/spec/tom_queue/stack_spec.rb
+++ b/spec/tom_queue/stack_spec.rb
@@ -1,0 +1,59 @@
+require "tom_queue/helper"
+
+describe TomQueue::Stack do
+  class Square < TomQueue::Stack::Layer
+    def call(a, b)
+      chain.call(a ** 2, b.merge(foo: "bar"))
+    end
+  end
+
+  class Add < TomQueue::Stack::Layer
+    def call(a, b)
+      value = config[:value] || 1
+      chain.call(a + value, b)
+    end
+  end
+
+  class TestStack < TomQueue::Stack
+    use Add, value: 2
+    use Square
+    use Add, value: 1
+    insert Add, value: 3
+
+    # result = ((x + 3 + 2) ** 2) + 1
+  end
+
+  specify "should compose layers and call them all in the correct order" do
+    value, options = TestStack.call(1, {})
+    expect(value).to eq(37)
+    expect(options).to eq({foo: "bar"})
+  end
+
+  describe TomQueue::Stack::Layer do
+    it "should be callable" do
+      value, options = Square.new.call(2, {})
+      expect(value).to eq(4)
+      expect(options).to eq({foo: "bar"})
+    end
+
+    it "should be chainable" do
+      layer = Square.new(Add.new())
+      expect(layer).to be_a(Square)
+      expect(layer.chain).to be_a(Add)
+      expect(layer.chain.chain).to eq(TomQueue::Stack::TERMINATOR)
+    end
+
+    it "should be configurable" do
+      layer = Square.new(nil, foo: "bar")
+      expect(layer.config[:foo]).to eq("bar")
+    end
+
+    it "should be appendable" do
+      layer = Square.new(Add.new)
+      expect(layer.chain.chain).to eq(TomQueue::Stack::TERMINATOR)
+      layer.append(Square, foo: "bar")
+      expect(layer.chain.chain).to be_a(Square)
+      expect(layer.chain.chain.config[:foo]).to eq("bar")
+    end
+  end
+end

--- a/test_app/spec/spec_helper.rb
+++ b/test_app/spec/spec_helper.rb
@@ -91,10 +91,7 @@ RSpec.configure do |config|
     TomQueue::DelayedJob.apply_hook!
   end
 
-  # Clear the RMQ queues before each spec
-  # config.before do
-  #   Delayed::Job.tomqueue_manager.queues.values.map(&:name).each do |name|
-  #     RestClient.delete("#{RMQ_API}/queues/#{AMQP_CONFIG[:vhost]}/#{name}/contents")
-  #   end
-  # end
+  config.before do
+    TomQueue.logger = Logger.new($stdout) if ENV['DEBUG']
+  end
 end

--- a/test_app/spec/spec_helper.rb
+++ b/test_app/spec/spec_helper.rb
@@ -87,6 +87,7 @@ RSpec.configure do |config|
 
     TomQueue.bunny = Bunny.new(AMQP_CONFIG)
     TomQueue.bunny.start
+    TomQueue.config[:override_enqueue] = ENV["NEUTER_DJ"] || false
     TomQueue::DelayedJob.apply_hook!
   end
 

--- a/tom_queue.gemspec
+++ b/tom_queue.gemspec
@@ -5,6 +5,7 @@ require_relative "lib/tom_queue/version"
 Gem::Specification.new do |spec|
   spec.add_dependency   'activerecord', '~> 4.1'
   spec.add_dependency   'delayed_job_active_record'
+  spec.add_dependency   'activesupport'
   spec.add_dependency   'bunny', "~> 2.2"
   spec.authors        = ["Thomas Haggett"]
   spec.description    = 'AMQP hook for Delayed Job, backed by ActiveRecord'


### PR DESCRIPTION
Redefine `Delayed::Job.enqueue` to skip the Delayed Job process, instead redefining it in terms of TomQueue "native" code as much as possible

To run the acceptance tests:
```
cd test_app
NEUTER_DJ=true rspec
```

To run the test suite
```
NEUTER_DJ=true rspec
```

TODO: 
* Allow non DJ work units to be passed in to `TomQueue.enqueue` for a standard interface
* Implement DJ persistence layer logic directly in TQ rather than subclassing `Delayed::Job`
* Implement worker process without DJ dependency
* Profit?