### PR TITLE
Allow the priorities to be customised and filtered per consumer

### DIFF
--- a/lib/tom_queue.rb
+++ b/lib/tom_queue.rb
@@ -8,6 +8,33 @@
 # You probably want to start with TomQueue::QueueManager
 #
 module TomQueue
+
+  # Public: Priority values for QueueManager#publish
+  #
+  # Rather than an arbitrary numeric scale, we use distinct
+  # priority values, one should be selected depending on the
+  # type and use-case of the work.
+  #
+  # The scheduler simply trumps lower-priority jobs with higher
+  # priority jobs. So ensure you don't saturate the worker with many
+  # or lengthy high priority jobs as you'll negatively impact normal
+  # and bulk jobs.
+  #
+  # HIGH_PRIORITY - use where the job is relatively short and the
+  #    user is waiting on completion. For example sending a password
+  #    reset email.
+  #
+  # NORMAL_PRIORITY - use for longer-interactive tasks (rebuilding ledgers?)
+  #
+  # BULK_PRIORITY - typically when you want to schedule lots of work to be done
+  #   at some point in the future - background emailing, cron-triggered
+  #   syncs, etc.
+  #
+  HIGH_PRIORITY = "high"
+  NORMAL_PRIORITY = "normal"
+  LOW_PRIORITY = "low"
+  BULK_PRIORITY = "bulk"
+  
   require 'tom_queue/logging_helper'
   
   require 'tom_queue/queue_manager'
@@ -50,60 +77,6 @@ module TomQueue
   class << self
     attr_accessor :exception_reporter
     attr_accessor :logger
-  end
-
-
-  # Public: Priority values for QueueManager#publish
-  #
-  # Rather than an arbitrary numeric scale, we use distinct
-  # priority values, one should be selected depending on the
-  # type and use-case of the work.
-  #
-  # The scheduler simply trumps lower-priority jobs with higher
-  # priority jobs. So ensure you don't saturate the worker with many
-  # or lengthy high priority jobs as you'll negatively impact normal
-  # and bulk jobs.
-  #
-  # HIGH_PRIORITY - use where the job is relatively short and the
-  #    user is waiting on completion. For example sending a password
-  #    reset email.
-  #
-  # NORMAL_PRIORITY - use for longer-interactive tasks (rebuilding ledgers?)
-  #
-  # BULK_PRIORITY - typically when you want to schedule lots of work to be done
-  #   at some point in the future - background emailing, cron-triggered
-  #   syncs, etc.
-  #
-  HIGH_PRIORITY = "high"
-  NORMAL_PRIORITY = "normal"
-  LOW_PRIORITY = "low"
-  BULK_PRIORITY = "bulk"
-
-  # Internal: A list of all the known priority values
-  #
-  # This array is where the priority ordering comes from, so get the
-  # order right!
-  @@priorities = [
-    HIGH_PRIORITY, 
-    NORMAL_PRIORITY,
-    LOW_PRIORITY,
-    BULK_PRIORITY
-  ]
-  @@default_priority = LOW_PRIORITY
-
-  def self.priorities=(new_priorities)
-    @@priorities = new_priorities
-  end
-  def self.priorities
-    @@priorities
-  end
-
-  @@queue_consumer_filter = lambda { |q| true }
-  def self.queue_consumer_filter=(new_proc)
-    @@queue_consumer_filter = new_proc
-  end
-  def self.queue_consumer_filter
-    @@queue_consumer_filter
   end
 
 end

--- a/lib/tom_queue.rb
+++ b/lib/tom_queue.rb
@@ -53,4 +53,57 @@ module TomQueue
   end
 
 
+  # Public: Priority values for QueueManager#publish
+  #
+  # Rather than an arbitrary numeric scale, we use distinct
+  # priority values, one should be selected depending on the
+  # type and use-case of the work.
+  #
+  # The scheduler simply trumps lower-priority jobs with higher
+  # priority jobs. So ensure you don't saturate the worker with many
+  # or lengthy high priority jobs as you'll negatively impact normal
+  # and bulk jobs.
+  #
+  # HIGH_PRIORITY - use where the job is relatively short and the
+  #    user is waiting on completion. For example sending a password
+  #    reset email.
+  #
+  # NORMAL_PRIORITY - use for longer-interactive tasks (rebuilding ledgers?)
+  #
+  # BULK_PRIORITY - typically when you want to schedule lots of work to be done
+  #   at some point in the future - background emailing, cron-triggered
+  #   syncs, etc.
+  #
+  HIGH_PRIORITY = "high"
+  NORMAL_PRIORITY = "normal"
+  LOW_PRIORITY = "low"
+  BULK_PRIORITY = "bulk"
+
+  # Internal: A list of all the known priority values
+  #
+  # This array is where the priority ordering comes from, so get the
+  # order right!
+  @@priorities = [
+    HIGH_PRIORITY, 
+    NORMAL_PRIORITY,
+    LOW_PRIORITY,
+    BULK_PRIORITY
+  ]
+  @@default_priority = LOW_PRIORITY
+
+  def self.priorities=(new_priorities)
+    @@priorities = new_priorities
+  end
+  def self.priorities
+    @@priorities
+  end
+
+  @@queue_consumer_filter = lambda { |q| true }
+  def self.queue_consumer_filter=(new_proc)
+    @@queue_consumer_filter = new_proc
+  end
+  def self.queue_consumer_filter
+    @@queue_consumer_filter
+  end
+
 end

--- a/lib/tom_queue/delayed_job/job.rb
+++ b/lib/tom_queue/delayed_job/job.rb
@@ -331,7 +331,7 @@ module TomQueue
         end
 
       rescue JSON::ParserError => e
-        work.ack!
+        work && work.ack!
         error "[reserve] Failed to parse JSON payload: #{e.message}. Dropping AMQP message."
 
         TomQueue.exception_reporter && TomQueue.exception_reporter.notify(e)

--- a/lib/tom_queue/external_consumer.rb
+++ b/lib/tom_queue/external_consumer.rb
@@ -154,7 +154,7 @@ module TomQueue
 
         # make sure the exchange is declared
         manager.channel.exchange(name, :type => type, :auto_delete => auto_delete, :durable => durable)
-        manager.queues[priority].bind(name, :routing_key => routing_key)
+        manager.queue(priority).bind(name, :routing_key => routing_key)
       end
     end
 

--- a/lib/tom_queue/queue_manager.rb
+++ b/lib/tom_queue/queue_manager.rb
@@ -8,6 +8,59 @@ module TomQueue
   #
   class QueueManager
 
+
+    # Internal: A list of all the known priority values
+    #
+    # This array is where the priority ordering comes from, so get the
+    # order right!
+    @@priorities = [
+      TomQueue::HIGH_PRIORITY, 
+      TomQueue::NORMAL_PRIORITY,
+      TomQueue::LOW_PRIORITY,
+      TomQueue::BULK_PRIORITY
+    ]
+
+    # Public: Allows the set of priorities to be managed externally. This must be
+    # specified before a QueueManger ojbects are instantiated.
+    #
+    # It is an Array of strings, being the priority names.
+    def self.priorities=(new_priorities)
+      @@priorities = new_priorities
+    end
+    def self.priorities
+      @@priorities
+    end
+
+    # Internal: This specifies how long the QueueManager should block before returning nil
+    # This is done to allow changes in the priority filters to take effect within a reasonable
+    # amount of time without complicated behaviour.
+    #
+    # Measured in seconds.
+    @@poll_interval = 10.0
+    def self.poll_interval=(new_interval)
+      @@poll_interval = new_interval
+    end
+    def self.poll_interval
+      @@poll_interval
+    end
+
+    # Public: An object that responds to #call(<QueuePriority instance>), returning a
+    # boolean indicating if the current process should consume messages from the
+    # given priority queue.
+    #
+    # Can be used by the parent process to only listen on certain queues on certain
+    # systems. By default, it just returns true.
+    #
+    # This proc will be called frequently, so it should return quickly.
+    #
+    @@priority_consumer_filter = lambda { |q| true }
+    def self.priority_consumer_filter=(new_proc)
+      @@priority_consumer_filter = new_proc
+    end
+    def self.priority_consumer_filter
+      @@priority_consumer_filter
+    end
+
     class QueuePriority
 
       attr_reader :name, :queue
@@ -36,6 +89,8 @@ module TomQueue
 
     include LoggingHelper
 
+
+
     # Public: Return the string used as a prefix for all queues and exchanges
     attr_reader :prefix
 
@@ -52,7 +107,8 @@ module TomQueue
 
     # Internal: Return the queue object for a given priority level
     def queue(priority)
-      priorities.find { |p| p.name == priority }.queue
+      priority = priorities.find { |p| p.name == priority }
+      priority.queue if priority
     end
 
     # Internal: The exchange to which work is published
@@ -119,7 +175,7 @@ module TomQueue
       @channel.open
       @channel.basic_qos(1, true)
 
-      @priorities = TomQueue.priorities.map do |name|
+      @priorities = TomQueue::QueueManager.priorities.map do |name|
         QueuePriority.new(name)
       end
 
@@ -217,7 +273,7 @@ module TomQueue
 
       # Synchronously poll the head of all the queues in priority order
       response = nil
-      @priorities.select { |priority| TomQueue.queue_consumer_filter.call(priority) }.find do |queue|
+      enabled_priorities.find do |queue|
         debug "[pop] Polling queue '#{queue}'..."
         response = queue.peek
       end
@@ -225,22 +281,29 @@ module TomQueue
       response && Work.new(self, *response)
     end
 
+    # Internal: The list of QueuePriority objects that this consumer should consume from
+    # 
+    # We establish this by simply asking the priority_consumer_filter hook that our parent
+    # app might override.
+    #
+    def enabled_priorities
+      @priorities.select { |priority| TomQueue::QueueManager.priority_consumer_filter.call(priority) }
+    end
+
     # Internal: Setup a consumer and block, waiting for the first message to arrive
     # on any of the priority queues.
     #
     # Returns: TomQueue::Work instance
     def wait_for_message
-
-      debug "[wait_for_message] setting up consumer, waiting for next message"
-
-      consumer_thread_value = nil
+      debug "[wait_for_message] setting up consumer, waiting for next message for priorities #{enabled_priorities.map {|q| q.name}.join(",")}"
 
       # Setup a subscription to all the queues. The channel pre-fetch
       # will ensure we get exactly one message delivered
-      consumers = @priorities.select { |priority| TomQueue.queue_consumer_filter.call(priority) }.map do |queue|
+      @consumer_thread_value = nil
+      @consumers = enabled_priorities.map do |queue|
         queue.wait do |*args|
           @mutex.synchronize do
-            consumer_thread_value = args
+            @consumer_thread_value = args
             @condvar.signal
           end
         end
@@ -249,18 +312,18 @@ module TomQueue
       # Back on the calling thread, block on the callback above and, when
       # it's signalled, pull the arguments over to this thread inside the mutex
       response, header, payload = @mutex.synchronize do
-        @condvar.wait(@mutex, 10.0) until consumer_thread_value
-        consumer_thread_value
+        @condvar.wait(@mutex, TomQueue::QueueManager.poll_interval)
+        @consumer_thread_value
       end
 
       debug "[wait_for_message] Shutting down consumers"
 
       # Now, cancel the consumers - the prefetch level on the channel will
       # ensure we only got the message we're about to return.
-      consumers.each { |c| c.cancel }
+      @consumers && @consumers.each { |c| c.cancel }
 
       # Return the message we got passed.
-      TomQueue::Work.new(self, response, header, payload)
+      response && TomQueue::Work.new(self, response, header, payload)
     end
   end
 end

--- a/spec/tom_queue/deferred_work/deferred_work_manager_integration_spec.rb
+++ b/spec/tom_queue/deferred_work/deferred_work_manager_integration_spec.rb
@@ -54,7 +54,7 @@ describe "DeferredWorkManager integration scenarios"  do
       @manager = TomQueue::DeferredWorkManager.new(@prefix)
       TomQueue.exception_reporter = double("ExceptionReporter", :notify => nil)
       @manager.out_manager.publish("work", :run_at => Time.now + 5)
-      @manager.deferred_set.should_receive(:pop).and_raise(RuntimeError, "Yaks Everywhere!")
+      allow(@manager.deferred_set).to receive(:pop).and_raise(RuntimeError, "Yaks Everywhere!")
       @manager.start
     end
 
@@ -63,7 +63,7 @@ describe "DeferredWorkManager integration scenarios"  do
     # we would expect the message to be on the queue again, so this
     # should "just work"
     ch = TomQueue.bunny.create_channel
-    ch.queue("#{@prefix}.work.deferred", durable: true).pop.last.should == "work"
+    expect(ch.queue("#{@prefix}.work.deferred", durable: true).pop.last).to eq("work")
   end
 
   describe "if the AMQP consumer thread crashes", timeout: 4 do
@@ -116,8 +116,8 @@ describe "DeferredWorkManager integration scenarios"  do
       crash!
       @queue_manager.publish("bar", :run_at => Time.now + 2)
 
-      @queue_manager.pop.ack!.payload.should == "foo"
-      @queue_manager.pop.ack!.payload.should == "bar"
+      expect(@queue_manager.pop.ack!.payload).to eq("foo")
+      expect(@queue_manager.pop.ack!.payload).to eq("bar")
     end
 
     it "should re-queue the message once" do

--- a/spec/tom_queue/deferred_work/deferred_work_manager_spec.rb
+++ b/spec/tom_queue/deferred_work/deferred_work_manager_spec.rb
@@ -22,20 +22,20 @@ describe TomQueue::DeferredWorkManager do
     it "should notify something if process crashes" do
       TomQueue.exception_reporter = double("ExceptionReporter", :notify => nil)
       subject.out_manager.publish("work", :run_at => Time.now + 5)
-      subject.deferred_set.should_receive(:pop).and_raise(RuntimeError, "Yaks Everywhere!")
-      TomQueue.exception_reporter.should_receive(:notify) do |exception|
-        exception.should be_a(RuntimeError)
-        exception.message.should == "Yaks Everywhere!"
+      allow(subject.deferred_set).to receive(:pop).and_raise(RuntimeError, "Yaks Everywhere!")
+      expect(TomQueue.exception_reporter).to receive(:notify) do |exception|
+        expect(exception).to be_a(RuntimeError)
+        expect(exception.message).to eq("Yaks Everywhere!")
       end
       subject.start
     end
 
     it "should notify something if consumer thread crashes and re-queue message once" do
       TomQueue.exception_reporter = double("ExceptionReporter", :notify => nil)
-      subject.deferred_set.should_receive(:schedule).twice.and_raise(RuntimeError, "Yaks Everywhere!")
-      TomQueue.exception_reporter.should_receive(:notify) do |exception|
-        exception.should be_a(RuntimeError)
-        exception.message.should == "Yaks Everywhere!"
+      allow(subject.deferred_set).to receive(:schedule).twice.and_raise(RuntimeError, "Yaks Everywhere!")
+      expect(TomQueue.exception_reporter).to receive(:notify) do |exception|
+        expect(exception).to be_a(RuntimeError)
+        expect(exception.message).to eq("Yaks Everywhere!")
       end
 
       subject.out_manager.publish("work", :run_at => Time.now + 5)

--- a/spec/tom_queue/deferred_work/deferred_work_set_spec.rb
+++ b/spec/tom_queue/deferred_work/deferred_work_set_spec.rb
@@ -4,32 +4,32 @@ describe TomQueue::DeferredWorkSet do
   let(:set) { TomQueue::DeferredWorkSet.new }
 
   it "should be creatable" do
-    set.should be_a(TomQueue::DeferredWorkSet)
+    expect(set).to be_a(TomQueue::DeferredWorkSet)
   end
 
   it "should allow work to be scheduled" do
     set.schedule(Time.now + 0.2, "something")
     set.schedule(Time.now + 0.3, "else")
-    set.size.should == 2
+    expect(set.size).to eq(2)
   end
 
   describe "earliest" do
 
     it "should return nil if there is no work in the set" do
-      set.earliest.should be_nil
+      expect(set.earliest).to be_nil
     end
 
     it "should return the only item if there is one item in the set" do
       work = double("Work")
       set.schedule( Time.now + 0.3, work)
-      set.earliest.should == work
+      expect(set.earliest).to eq(work)
     end
 
     it "should return the item in the set with the lowest run_at value" do
       set.schedule( Time.now + 0.2, work1 = double("Work") )
       set.schedule( Time.now + 0.1, work2 = double("Work") )
       set.schedule( Time.now + 0.3, work3 = double("Work") )
-      set.earliest.should == work2
+      expect(set.earliest).to eq(work2)
     end
 
   end
@@ -37,13 +37,13 @@ describe TomQueue::DeferredWorkSet do
   describe "pop" do
 
     it "should return nil when the timeout expires" do
-      set.pop(0.1).should be_nil
+      expect(set.pop(0.1)).to be_nil
     end
 
     it "should block for the timeout value if there is no work in the queue" do
       start_time = Time.now
       set.pop(0.1)
-      Time.now.should > start_time + 0.1
+      expect(Time.now).to be > (start_time + 0.1)
     end
 
     it "should block until the earliest work in the set" do
@@ -51,32 +51,32 @@ describe TomQueue::DeferredWorkSet do
       set.schedule(start_time + 1.5, "work")
       set.schedule(start_time + 0.1, "work")
       set.pop(10)
-      Time.now.should > start_time + 0.1
-      Time.now.should < start_time + 0.2
+      expect(Time.now).to be > (start_time + 0.1)
+      expect(Time.now).to be < (start_time + 0.2)
     end
 
     it "should return immediately if tehre is work scheduled in the past" do
       set.schedule(Time.now - 0.1, "work")
-      set.pop(10).should == "work"
+      expect(set.pop(10)).to eq("work")
     end
 
     it "should have removed the returned work from the set" do
       set.schedule(Time.now - 0.1, "work")
       set.pop(10)
-      set.size.should == 0
+      expect(set.size).to eq(0)
     end
 
     it "should return old work in temporal order" do
       set.schedule(Time.now - 0.1, "work2")
       set.schedule(Time.now - 0.2, "work1")
-      set.pop(10).should == "work1"
-      set.pop(10).should == "work2"
+      expect(set.pop(10)).to eq("work1")
+      expect(set.pop(10)).to eq("work2")
     end
 
     it "should return the earliest work" do
       start_time = Time.now
       set.schedule(start_time + 0.1, "work")
-      set.pop(10).should == "work"
+      expect(set.pop(10)).to eq("work")
     end
 
     it "should block until the earliest work, even if earlier work is added after the block" do
@@ -87,8 +87,8 @@ describe TomQueue::DeferredWorkSet do
       end
       set.schedule(start_time + 1.5, "late")
       set.pop(10)
-      Time.now.should > start_time + 0.2
-      Time.now.should < start_time + 0.3
+      expect(Time.now).to be > (start_time + 0.2)
+      expect(Time.now).to be < (start_time + 0.3)
     end
 
     it "should raise an exception if two threads try to block on the same work set" do
@@ -96,9 +96,9 @@ describe TomQueue::DeferredWorkSet do
         set.pop(1)
       end
       sleep 0.1
-      lambda {
+      expect {
         set.pop(1)
-      }.should raise_exception(/another thread is already blocked/)
+      }.to raise_exception(/another thread is already blocked/)
     end
 
     it "should not get deferred items caught outside the cache" do
@@ -106,18 +106,18 @@ describe TomQueue::DeferredWorkSet do
       50.times { |i| set.schedule(start_time+0.1+i*0.001, "bulk") }
       set.schedule(start_time+0.2, "missing")
 
-      50.times { set.pop(1).should == "bulk" }
+      50.times { expect(set.pop(1)).to eq("bulk") }
 
       set.schedule(start_time+0.3, "final")
-      set.pop(1).should == "missing"
-      set.pop(1).should == "final"
+      expect(set.pop(1)).to eq("missing")
+      expect(set.pop(1)).to eq("final")
     end
 
     it "should not delete all elements with the same run_at" do
       the_time = Time.now + 0.1
       set.schedule(the_time, "work-1")
       set.schedule(the_time, "work-2")
-      2.times.collect { set.pop(1) }.sort.should == ["work-1", "work-2"]
+      expect(2.times.collect { set.pop(1) }.sort).to eq(["work-1", "work-2"])
     end
   end
 

--- a/spec/tom_queue/delayed_job/delayed_job_integration_spec.rb
+++ b/spec/tom_queue/delayed_job/delayed_job_integration_spec.rb
@@ -56,33 +56,33 @@ describe Delayed::Job, "integration spec", :timeout => 10 do
     Delayed::Job.enqueue(TestJobClass.new(job_name))
 
     sleep 0.25
-    Delayed::Job.tomqueue_manager.queues[TomQueue::NORMAL_PRIORITY].status[:message_count].should == 1
+    expect(Delayed::Job.tomqueue_manager.priorities.find { |q| q.name == TomQueue::NORMAL_PRIORITY }.queue.status[:message_count]).to eq(1)
   end
 
   it "should integrate with Delayed::Worker" do
     Delayed::Job.enqueue(TestJobClass.new(job_name))
 
-    Delayed::Worker.new.work_off(1).should == [1, 0] # 1 success, 0 failed
-    @called.first.should == job_name
+    expect(Delayed::Worker.new.work_off(1)).to eq([1, 0]) # 1 success, 0 failed
+    expect(@called.first).to eq(job_name)
   end
 
   it "should still back-off jobs", deferred_work_manager: true do
     Delayed::Job.enqueue(TestJobClass.new(job_name))
     TestJobClass.flunk_count = 1
 
-    Benchmark.realtime {
-      Delayed::Worker.new.work_off(1).should == [0, 1]
-      Delayed::Worker.new.work_off(1).should == [1, 0]
-    }.should > 0.5
+    expect(Benchmark.realtime {
+      expect(Delayed::Worker.new.work_off(1)).to eq([0, 1])
+      expect(Delayed::Worker.new.work_off(1)).to eq([1, 0])
+    }).to be > 0.5
   end
 
   it "should support run_at", deferred_work_manager: true do
-    Benchmark.realtime {
+    expect(Benchmark.realtime {
       Delayed::Job.enqueue(TestJobClass.new("job1"), :run_at => Time.now + 5)
       Delayed::Job.enqueue(TestJobClass.new("job2"), :run_at => Time.now + 1)
-      Delayed::Worker.new.work_off(2).should == [2, 0]
-    }.should > 0.1
-    @called.should == ["job2", "job1"]
+      expect(Delayed::Worker.new.work_off(2)).to eq([2, 0])
+    }).to be > 0.1
+    expect(@called).to eq(["job2", "job1"])
   end
 
   it "should support job priorities" do
@@ -94,7 +94,7 @@ describe Delayed::Job, "integration spec", :timeout => 10 do
     Delayed::Job.enqueue(TestJobClass.new("low3"), :priority => 0)
     Delayed::Job.enqueue(TestJobClass.new("low4"), :priority => 0)
     Delayed::Worker.new.work_off(5)
-    @called.should == ["high", "low1", "low2", "low3", "low4"]
+    expect(@called).to eq(["high", "low1", "low2", "low3", "low4"])
   end
 
   it "should not run a failed job" do
@@ -110,7 +110,7 @@ describe Delayed::Job, "integration spec", :timeout => 10 do
     job.last_error = "Some error"
     job.save
 
-    job.should be_failed
+    expect(job).to be_failed
 
     Delayed::Job.tomqueue_republish
 
@@ -119,21 +119,21 @@ describe Delayed::Job, "integration spec", :timeout => 10 do
     Delayed::Worker.new.work_off(1)
 
     # And, since it never got run, it should still exist!
-    Delayed::Job.find_by_id(job.id).should_not be_nil
+    expect(Delayed::Job.find_by_id(job.id)).to_not be_nil
     # And it should have been noisy, too.
-    File.read(logfile.path).should =~ /Received notification for failed job #{job.id}/
+    expect(File.read(logfile.path)).to be =~ /Received notification for failed job #{job.id}/
   end
 
   it "should remove the job from the queue after it has run" do
     Delayed::Job.enqueue(TestJobClass.new(job_name))
 
     sleep 0.25
-    Delayed::Job.tomqueue_manager.queues[TomQueue::NORMAL_PRIORITY].status[:message_count].should == 1
+    expect(Delayed::Job.tomqueue_manager.priorities.find { |p| p.name == TomQueue::NORMAL_PRIORITY }.queue.status[:message_count]).to eq(1)
     Delayed::Worker.new.work_off(1)
 
     sleep 2
     expect(unacked_message_count(TomQueue::NORMAL_PRIORITY)).to eq 0
-    Delayed::Job.tomqueue_manager.queues[TomQueue::NORMAL_PRIORITY].status[:message_count].should == 0
+    expect(Delayed::Job.tomqueue_manager.priorities.find { |p| p.name == TomQueue::NORMAL_PRIORITY }.queue.status[:message_count]).to eq(0)
   end
 
   # it "should re-run the job once max_run_time is reached if, say, a worker crashes" do

--- a/spec/tom_queue/delayed_job/delayed_job_spec.rb
+++ b/spec/tom_queue/delayed_job/delayed_job_spec.rb
@@ -10,40 +10,40 @@ describe TomQueue, "once hooked" do
     # This makes sure the Delayed::Worker loop spins around on
     # an empty queue to block on TomQueue::QueueManager#pop, so
     # the job will start as soon as we receive a push from RMQ
-    Delayed::Worker.sleep_delay.should == 0
+    expect(Delayed::Worker.sleep_delay).to eq(0)
   end
 
   describe "TomQueue::DelayedJob::Job" do
     it "should use the TomQueue job as the Delayed::Job" do
-      Delayed::Job.should == TomQueue::DelayedJob::Job
+      expect(Delayed::Job).to eq(TomQueue::DelayedJob::Job)
     end
 
     it "should be a subclass of ::Delayed::Backend::ActiveRecord::Job" do
-      TomQueue::DelayedJob::Job.superclass.should == ::Delayed::Backend::ActiveRecord::Job
+      expect(TomQueue::DelayedJob::Job.superclass).to eq(::Delayed::Backend::ActiveRecord::Job)
     end
   end
 
   describe "Delayed::Job.tomqueue_manager" do
     it "should return a TomQueue::QueueManager instance" do
-      Delayed::Job.tomqueue_manager.should be_a(TomQueue::QueueManager)
+      expect(Delayed::Job.tomqueue_manager).to be_a(TomQueue::QueueManager)
     end
 
     it "should have used the default prefix configured" do
-      Delayed::Job.tomqueue_manager.prefix.should == TomQueue.default_prefix
+      expect(Delayed::Job.tomqueue_manager.prefix).to eq(TomQueue.default_prefix)
     end
 
     it "should return the same object on subsequent calls" do
-      Delayed::Job.tomqueue_manager.should == Delayed::Job.tomqueue_manager
+      expect(Delayed::Job.tomqueue_manager).to eq(Delayed::Job.tomqueue_manager)
     end
 
     it "should be reset by rspec (1)" do
       TomQueue.default_prefix = "foo"
-      Delayed::Job.tomqueue_manager.prefix.should == "foo"
+      expect(Delayed::Job.tomqueue_manager.prefix).to eq("foo")
     end
 
     it "should be reset by rspec (2)" do
       TomQueue.default_prefix = "bar"
-      Delayed::Job.tomqueue_manager.prefix.should == "bar"
+      expect(Delayed::Job.tomqueue_manager.prefix).to eq("bar")
     end
   end
 
@@ -52,7 +52,7 @@ describe TomQueue, "once hooked" do
     it "should return a different value when the object is saved" do
       first_digest = job.tomqueue_digest
       job.update_attributes(:run_at => Time.now + 10.seconds)
-      job.tomqueue_digest.should_not == first_digest
+      expect(job.tomqueue_digest).to_not eq(first_digest)
     end
 
     it "should return the same value, regardless of the time zone (regression)" do
@@ -65,7 +65,7 @@ describe TomQueue, "once hooked" do
       Time.zone = "Auckland"
 
       job = Delayed::Job.find(job.id)
-      job.tomqueue_digest.should == first_digest
+      expect(job.tomqueue_digest).to eq(first_digest)
 
       Time.zone = old_zone
     end
@@ -76,33 +76,33 @@ describe TomQueue, "once hooked" do
     let(:payload) { JSON.load(job.tomqueue_payload)}
 
     it "should return a hash" do
-      payload.should be_a(Hash)
+      expect(payload).to be_a(Hash)
     end
 
     it "should contain the job id" do
-      payload['delayed_job_id'].should == job.id
+      expect(payload['delayed_job_id']).to eq(job.id)
     end
 
     it "should contain the current updated_at timestamp (with second-level precision)" do
-      payload['delayed_job_updated_at'].should == job.updated_at.iso8601(0)
+      expect(payload['delayed_job_updated_at']).to eq(job.updated_at.iso8601(0))
     end
 
     it "should contain the digest after saving" do
-      payload['delayed_job_digest'].should == job.tomqueue_digest
+      expect(payload['delayed_job_digest']).to eq(job.tomqueue_digest)
     end
   end
 
   describe "Delayed::Job#tomqueue_publish" do
 
     it "should return nil" do
-      job.tomqueue_publish.should be_nil
+      expect(job.tomqueue_publish).to be_nil
     end
 
     it "should raise an exception if it is called on an unsaved job" do
       TomQueue.exception_reporter = double("SilentExceptionReporter", :notify => nil)
-      lambda {
+      expect {
         Delayed::Job.new.tomqueue_publish
-      }.should raise_exception(ArgumentError, /cannot publish an unsaved Delayed::Job/)
+      }.to raise_exception(ArgumentError, /cannot publish an unsaved Delayed::Job/)
     end
 
     describe "when it is called on a persisted job" do
@@ -111,7 +111,7 @@ describe TomQueue, "once hooked" do
         job # create the job first so we don't trigger the expectation twice
 
         @called = false
-        Delayed::Job.tomqueue_manager.should_receive(:publish) do |payload, opts|
+        allow(Delayed::Job.tomqueue_manager).to receive(:publish) do |payload, opts|
           @called = true
           @payload = payload
           @opts = opts
@@ -120,7 +120,7 @@ describe TomQueue, "once hooked" do
 
       it "should call publish on the queue manager" do
         job.tomqueue_publish
-        @called.should be_truthy
+        expect(@called).to be_truthy
       end
 
       describe "job priority" do
@@ -132,7 +132,7 @@ describe TomQueue, "once hooked" do
         it "should map the priority of the job to the TomQueue priority" do
           new_job.priority = -10
           new_job.save
-          @opts[:priority].should == TomQueue::BULK_PRIORITY
+          expect(@opts[:priority]).to eq(TomQueue::BULK_PRIORITY)
         end
 
         describe "if an unknown priority value is used" do
@@ -142,11 +142,11 @@ describe TomQueue, "once hooked" do
 
           it "should default the priority to TomQueue::NORMAL_PRIORITY" do
             new_job.save
-            @opts[:priority].should == TomQueue::NORMAL_PRIORITY
+            expect(@opts[:priority]).to eq(TomQueue::NORMAL_PRIORITY)
           end
 
           it "should log a warning" do
-            TomQueue.logger.should_receive(:warn)
+            allow(TomQueue.logger).to receive(:warn)
             new_job.save
           end
         end
@@ -156,24 +156,24 @@ describe TomQueue, "once hooked" do
 
         it "should use the job's :run_at value by default" do
           job.tomqueue_publish
-          @opts[:run_at].should == job.run_at
+          expect(@opts[:run_at]).to eq(job.run_at)
         end
 
         it "should use the run_at value provided if provided by the caller" do
           the_time = Time.now + 10.seconds
           job.tomqueue_publish(the_time)
-          @opts[:run_at].should == the_time
+          expect(@opts[:run_at]).to eq(the_time)
         end
 
       end
 
       describe "the payload" do
 
-        before { job.stub(:tomqueue_payload => "PAYLOAD") }
+        before { allow(job).to receive(:tomqueue_payload).and_return("PAYLOAD") }
 
         it "should be the return value from #tomqueue_payload" do
           job.tomqueue_publish
-          @payload.should == "PAYLOAD"
+          expect(@payload).to eq("PAYLOAD")
         end
       end
     end
@@ -183,25 +183,25 @@ describe TomQueue, "once hooked" do
 
       before do
         TomQueue.exception_reporter = double("SilentExceptionReporter", :notify => nil)
-        Delayed::Job.tomqueue_manager.should_receive(:publish).and_raise(exception)
+        allow(Delayed::Job.tomqueue_manager).to receive(:publish).and_raise(exception)
       end
 
       it "should not be raised out to the caller" do
-        lambda { new_job.save }.should_not raise_exception
+        expect { new_job.save }.to_not raise_exception
       end
 
       it "should notify the exception reporter" do
-        TomQueue.exception_reporter.should_receive(:notify).with(exception)
+        expect(TomQueue.exception_reporter).to receive(:notify).with(exception)
         new_job.save
       end
 
       it "should do nothing if the exception reporter is nil" do
         TomQueue.exception_reporter = nil
-        lambda { new_job.save }.should_not raise_exception
+        expect { new_job.save }.to_not raise_exception
       end
 
       it "should log an error message to the log" do
-        TomQueue.logger.should_receive(:error)
+        expect(TomQueue.logger).to receive(:error)
         new_job.save
       end
     end
@@ -212,80 +212,80 @@ describe TomQueue, "once hooked" do
     it "should allow Mock::ExpectationFailed exceptions to escape the callback" do
       TomQueue.logger = Logger.new("/dev/null")
       TomQueue.exception_reporter = nil
-      Delayed::Job.tomqueue_manager.should_receive(:publish).with("spurious arguments").once
-      lambda {
+      allow(Delayed::Job.tomqueue_manager).to receive(:publish).with("spurious arguments").once
+      expect {
         job.update_attributes(:run_at => Time.now + 5.seconds)
-      }.should raise_exception(RSpec::Mocks::MockExpectationError)
+      }.to raise_exception(RSpec::Mocks::MockExpectationError)
 
       Delayed::Job.tomqueue_manager.publish("spurious arguments") # do this, otherwise it will fail
     end
 
     it "should not publish a message if the job has a non-nil failed_at" do
-      job.should_not_receive(:tomqueue_publish)
+      expect(job).to_not receive(:tomqueue_publish)
       job.update_attributes(:failed_at => Time.now)
     end
 
     it "should be called after create when there is no explicit transaction" do
-      new_job.should_receive(:tomqueue_publish).with(no_args)
+      expect(new_job).to receive(:tomqueue_publish).with(no_args)
       new_job.save!
     end
 
     it "should be called after update when there is no explicit transaction" do
-      job.should_receive(:tomqueue_publish).with(no_args)
+      expect(job).to receive(:tomqueue_publish).with(no_args)
       job.run_at = Time.now + 10.seconds
       job.save!
     end
 
     it "should be called after commit, when a record is saved" do
-      new_job.stub(:tomqueue_publish) { @called = true }
+      allow(new_job).to receive(:tomqueue_publish) { @called = true }
       Delayed::Job.transaction do
         new_job.save!
 
-        @called.should be_nil
+        expect(@called).to be_nil
       end
-      @called.should be_truthy
+      expect(@called).to be_truthy
     end
 
     it "should be called after commit, when a record is updated" do
-      job.stub(:tomqueue_publish) { @called = true }
+      allow(job).to receive(:tomqueue_publish) { @called = true }
       Delayed::Job.transaction do
         job.run_at = Time.now + 10.seconds
         job.save!
-        @called.should be_nil
+        expect(@called).to be_nil
       end
 
-      @called.should be_truthy
+      expect(@called).to be_truthy
     end
 
     it "should not be called when a record is destroyed" do
-      job.should_not_receive(:tomqueue_publish)
+      expect(job).to_not receive(:tomqueue_publish)
       job.destroy
     end
 
     it "should not be called by a destroy in a transaction" do
-      job.should_not_receive(:tomqueue_publish)
+      expect(job).to_not receive(:tomqueue_publish)
       Delayed::Job.transaction { job.destroy }
     end
 
     it "should not be called if the update transaction is rolled back" do
-      job.stub(:tomqueue_publish) { @called = true }
+      allow(job).to receive(:tomqueue_publish) { @called = true }
 
       Delayed::Job.transaction do
         job.run_at = Time.now + 10.seconds
         job.save!
         raise ActiveRecord::Rollback
       end
-      @called.should be_nil
+      expect(@called).to be_nil
     end
 
     it "should not be called if the create transaction is rolled back" do
-      job.should_not_receive(:tomqueue_publish)
+      expect(job).to_not receive(:tomqueue_publish)
 
       Delayed::Job.transaction do
         new_job.save!
         raise ActiveRecord::Rollback
       end
-      @called.should be_nil
+      expect(@called).to be_nil
     end
   end
 
@@ -293,43 +293,43 @@ describe TomQueue, "once hooked" do
     before { Delayed::Job.delete_all }
 
     it "should exist" do
-      Delayed::Job.respond_to?(:tomqueue_republish).should be_truthy
+      expect(Delayed::Job.respond_to?(:tomqueue_republish)).to be_truthy
     end
 
     it "should return nil" do
-      Delayed::Job.tomqueue_republish.should be_nil
+      expect(Delayed::Job.tomqueue_republish).to be_nil
     end
 
     it "should call #tomqueue_publish on all DB records" do
       10.times { Delayed::Job.create! }
 
-      Delayed::Job.tomqueue_manager.queues[TomQueue::NORMAL_PRIORITY].purge
-      queue = Delayed::Job.tomqueue_manager.queues[TomQueue::NORMAL_PRIORITY]
-      queue.message_count.should == 0
+      Delayed::Job.tomqueue_manager.queue(TomQueue::NORMAL_PRIORITY).purge
+      queue = Delayed::Job.tomqueue_manager.queue(TomQueue::NORMAL_PRIORITY)
+      expect(queue.message_count).to eq(0)
 
       Delayed::Job.tomqueue_republish
       sleep 0.25
-      queue.message_count.should == 10
+      expect(queue.message_count).to eq(10)
     end
 
     it "should work with ActiveRecord scopes" do
       first_ids = 10.times.collect { Delayed::Job.create!.id }
       second_ids = 7.times.collect { Delayed::Job.create!.id }
 
-      Delayed::Job.tomqueue_manager.queues[TomQueue::NORMAL_PRIORITY].purge
-      queue = Delayed::Job.tomqueue_manager.queues[TomQueue::NORMAL_PRIORITY]
-      queue.message_count.should == 0
+      Delayed::Job.tomqueue_manager.queue(TomQueue::NORMAL_PRIORITY).purge
+      queue = Delayed::Job.tomqueue_manager.queue(TomQueue::NORMAL_PRIORITY)
+      expect(queue.message_count).to eq(0)
 
       Delayed::Job.where('id IN (?)', second_ids).tomqueue_republish
       sleep 0.25
-      queue.message_count.should == 7
+      expect(queue.message_count).to eq(7)
     end
 
   end
 
   describe "Delayed::Job.acquire_locked_job" do
     let(:time) { Delayed::Job.db_time_now }
-    before { Delayed::Job.stub(:db_time_now => time) }
+    before { allow(Delayed::Job).to receive(:db_time_now).and_return(time) }
 
     let(:job) { Delayed::Job.create! }
     let(:worker) { Delayed::Worker.new }
@@ -343,13 +343,13 @@ describe TomQueue, "once hooked" do
       before { job.destroy }
 
       it "should return nil" do
-        subject.should be_nil
+        expect(subject).to be_nil
       end
 
       it "should not yield if a block is provided" do
         @block = lambda { |value| @called = true}
         subject
-        @called.should be_nil
+        expect(@called).to be_nil
       end
     end
 
@@ -364,8 +364,8 @@ describe TomQueue, "once hooked" do
         ActiveRecord::Base.connection.reset!
 
         # Assert we have separate connections
-        second_connection.execute("SELECT connection_id() as id;").first.should_not ==
-          ActiveRecord::Base.connection.execute("SELECT connection_id() as id;").first
+        expect(second_connection.execute("SELECT connection_id() as id;").first).to_not eq(
+          ActiveRecord::Base.connection.execute("SELECT connection_id() as id;").first)
 
         # This is called in a thread when the transaction is open to query the job, store the response
         # and the time when the response comes back
@@ -393,11 +393,11 @@ describe TomQueue, "once hooked" do
         @thread.join
 
         # now make sure the parallel thread blocked until the transaction returned
-        @query_returned_at.should > @leaving_transaction_at
+        expect(@query_returned_at).to be > @leaving_transaction_at
 
         # make sure the returned record showed the lock
-        @query_result[0].should_not be_nil
-        @query_result[1].should_not be_nil
+        expect(@query_result[0]).to_not be_nil
+        expect(@query_result[1]).to_not be_nil
       end
 
       describe "when the job is marked as failed" do
@@ -408,20 +408,20 @@ describe TomQueue, "once hooked" do
         end
 
         it "should return nil" do
-          subject.should be_nil
+          expect(subject).to be_nil
         end
 
         it "should not modify the failed_at value" do
           subject
           job.reload
-          job.failed_at.to_i.should == failed_time.to_i
+          expect(job.failed_at.to_i).to eq(failed_time.to_i)
         end
 
         it "should not lock the job" do
           subject
           job.reload
-          job.locked_by.should be_nil
-          job.locked_at.should be_nil
+          expect(job.locked_by).to be_nil
+          expect(job.locked_at).to be_nil
         end
       end
 
@@ -429,16 +429,16 @@ describe TomQueue, "once hooked" do
 
         before do
           actual_time = Delayed::Job.db_time_now
-          Delayed::Job.stub(:db_time_now => actual_time - 10)
+          allow(Delayed::Job).to receive(:db_time_now).and_return(actual_time - 10)
         end
 
         it "should return nil" do
-          subject.should be_nil
+          expect(subject).to be_nil
         end
 
         it "should re-post a notification" do
-          Delayed::Job.tomqueue_manager.should_receive(:publish) do |payload, args|
-            args[:run_at].to_i.should == job.run_at.to_i
+          expect(Delayed::Job.tomqueue_manager).to receive(:publish) do |payload, args|
+            expect(args[:run_at].to_i).to eq(job.run_at.to_i)
           end
           subject
         end
@@ -446,8 +446,8 @@ describe TomQueue, "once hooked" do
         it "should not lock the job" do
           subject
           job.reload
-          job.locked_by.should be_nil
-          job.locked_at.should be_nil
+          expect(job.locked_by).to be_nil
+          expect(job.locked_at).to be_nil
         end
 
       end
@@ -457,26 +457,26 @@ describe TomQueue, "once hooked" do
         it "should acquire the lock fields on the job" do
           subject
           job.reload
-          job.locked_at.to_i.should == time.to_i
-          job.locked_by.should == worker.name
+          expect(job.locked_at.to_i).to eq(time.to_i)
+          expect(job.locked_by).to eq(worker.name)
         end
 
         it "should return the job object" do
-          subject.should be_a(Delayed::Job)
-          subject.id.should == job.id
+          expect(subject).to be_a(Delayed::Job)
+          expect(subject.id).to eq(job.id)
         end
 
         it "should yield the job to the block if present" do
           @block = lambda { |value| @called = value}
           subject
-          @called.should be_a(Delayed::Job)
-          @called.id.should == job.id
+          expect(@called).to be_a(Delayed::Job)
+          expect(@called.id).to eq(job.id)
         end
 
         it "should not have locked the job when the block is called" do
           @block = lambda { |job| @called = [job.id, job.locked_at, job.locked_by]; true }
           subject
-          @called.should == [job.id, nil, nil]
+          expect(@called).to eq([job.id, nil, nil])
         end
 
         describe "if the supplied block returns true" do
@@ -485,13 +485,13 @@ describe TomQueue, "once hooked" do
           it "should lock the job" do
             subject
             job.reload
-            job.locked_at.to_i.should == time.to_i
-            job.locked_by.should == worker.name
+            expect(job.locked_at.to_i).to eq(time.to_i)
+            expect(job.locked_by).to eq(worker.name)
           end
 
           it "should return the job" do
-            subject.should be_a(Delayed::Job)
-            subject.id.should == job.id
+            expect(subject).to be_a(Delayed::Job)
+            expect(subject.id).to eq(job.id)
           end
         end
 
@@ -501,12 +501,12 @@ describe TomQueue, "once hooked" do
           it "should not lock the job" do
             subject
             job.reload
-            job.locked_at.should be_nil
-            job.locked_by.should be_nil
+            expect(job.locked_at).to be_nil
+            expect(job.locked_by).to be_nil
           end
 
           it "should return nil" do
-            subject.should be_nil
+            expect(subject).to be_nil
           end
         end
       end
@@ -523,18 +523,18 @@ describe TomQueue, "once hooked" do
           @called = false
           @block = lambda { |_| @called = true}
           subject
-          @called.should be_falsy
+          expect(@called).to be_falsy
         end
 
         it "should return false" do
-          subject.should be_falsy
+          expect(subject).to be_falsy
         end
 
         it "should not change the lock" do
           subject
           job.reload
-          job.locked_by.should == @old_locked_by
-          job.locked_at.to_i.should == @old_locked_at.to_i
+          expect(job.locked_by).to eq(@old_locked_by)
+          expect(job.locked_at.to_i).to eq(@old_locked_at.to_i)
         end
 
       end
@@ -547,15 +547,15 @@ describe TomQueue, "once hooked" do
         end
 
         it "should return the job" do
-          subject.should be_a(Delayed::Job)
-          subject.id.should == job.id
+          expect(subject).to be_a(Delayed::Job)
+          expect(subject.id).to eq(job.id)
         end
 
         it "should update the lock" do
           subject
           job.reload
-          job.locked_at.should_not == @old_locked_at
-          job.locked_by.should_not == @old_locked_by
+          expect(job.locked_at).to_not eq(@old_locked_at)
+          expect(job.locked_by).to_not eq(@old_locked_by)
         end
 
         # This is tricky - if we have a stale lock, the job object
@@ -569,7 +569,7 @@ describe TomQueue, "once hooked" do
           @called = false
           @block = lambda { |_| @called = true}
           subject
-          @called.should be_falsy
+          expect(@called).to be_falsy
         end
       end
 
@@ -585,11 +585,11 @@ describe TomQueue, "once hooked" do
     subject { Delayed::Job.reserve(worker) }
 
     before do
-      Delayed::Job.tomqueue_manager.stub(:pop => work)
+      allow(Delayed::Job.tomqueue_manager).to receive(:pop).and_return(work)
     end
 
     it "should call pop on the queue manager" do
-      Delayed::Job.tomqueue_manager.should_receive(:pop)
+      expect(Delayed::Job.tomqueue_manager).to receive(:pop)
 
       subject
     end
@@ -597,8 +597,8 @@ describe TomQueue, "once hooked" do
     describe "signal handling" do
       it "should allow signal handlers during the pop" do
         Delayed::Worker.raise_signal_exceptions = false
-        Delayed::Job.tomqueue_manager.should_receive(:pop) do
-          Delayed::Worker.raise_signal_exceptions.should be_truthy
+        expect(Delayed::Job.tomqueue_manager).to receive(:pop) do
+          expect(Delayed::Worker.raise_signal_exceptions).to be_truthy
           work
         end
         Delayed::Job.reserve(worker)
@@ -607,17 +607,17 @@ describe TomQueue, "once hooked" do
       it "should reset the signal handler var after the pop" do
         Delayed::Worker.raise_signal_exceptions = false
         subject
-        Delayed::Worker.raise_signal_exceptions.should == false
+        expect(Delayed::Worker.raise_signal_exceptions).to eq(false)
       end
 
       it "should reset the signal handler var even if it's already true" do
         Delayed::Worker.raise_signal_exceptions = true
         subject
-        Delayed::Worker.raise_signal_exceptions.should == true
+        expect(Delayed::Worker.raise_signal_exceptions).to eq(true)
       end
 
       it "should not allow signal exceptions to escape the function" do
-        Delayed::Job.tomqueue_manager.should_receive(:pop) do
+        allow(Delayed::Job.tomqueue_manager).to receive(:pop) do
           raise SignalException, "INT"
         end
 
@@ -625,7 +625,7 @@ describe TomQueue, "once hooked" do
       end
 
       it "should allow exceptions to escape the function" do
-        Delayed::Job.tomqueue_manager.should_receive(:pop) do
+        allow(Delayed::Job.tomqueue_manager).to receive(:pop) do
           raise Exception, "Something went wrong"
         end
         expect { subject }.to raise_error(Exception)
@@ -633,16 +633,16 @@ describe TomQueue, "once hooked" do
     end
 
     describe "if a nil message is popped" do
-      before { Delayed::Job.tomqueue_manager.stub(:pop=>nil) }
+      before { allow(Delayed::Job.tomqueue_manager).to receive(:pop).and_return(nil) }
 
       it "should return nil" do
-        subject.should be_nil
+        expect(subject).to be_nil
       end
 
       it "should sleep for a second to avoid potentially tight loops" do
         start_time = Time.now
         subject
-        (Time.now - start_time).should > 1.0
+        expect(Time.now - start_time).to be > 1.0
       end
     end
 
@@ -653,7 +653,7 @@ describe TomQueue, "once hooked" do
 
       it "should report an exception" do
         TomQueue.exception_reporter = double("Reporter", :notify => nil)
-        TomQueue.exception_reporter.should_receive(:notify).with(instance_of(JSON::ParserError))
+        expect(TomQueue.exception_reporter).to receive(:notify).with(instance_of(JSON::ParserError))
         subject
       end
 
@@ -663,30 +663,30 @@ describe TomQueue, "once hooked" do
       end
 
       it "should ack the message" do
-        work.should_receive(:ack!)
+        expect(work).to receive(:ack!)
         subject
       end
 
       it "should log an error" do
-        TomQueue.logger.should_receive(:error)
+        expect(TomQueue.logger).to receive(:error)
         subject
       end
 
       it "should return nil" do
-        subject.should be_nil
+        expect(subject).to be_nil
       end
     end
 
     it "should call acquire_locked_job with the job_id and the worker" do
-      Delayed::Job.should_receive(:acquire_locked_job).with(job.id, worker)
+      expect(Delayed::Job).to receive(:acquire_locked_job).with(job.id, worker)
       subject
     end
 
     it "should attach a block to the call to acquire_locked_job" do
       def stub_implementation(job_id, worker, &block)
-        block.should_not be_nil
+        expect(block).to_not be_nil
       end
-      Delayed::Job.should_receive(:acquire_locked_job, &method(:stub_implementation)).and_return(job)
+      allow(Delayed::Job).to receive(:acquire_locked_job, &method(:stub_implementation)).and_return(job)
       subject
     end
 
@@ -695,24 +695,24 @@ describe TomQueue, "once hooked" do
         def stub_implementation(job_id, worker, &block)
           @block = block
         end
-        Delayed::Job.should_receive(:acquire_locked_job, &method(:stub_implementation)).and_return(job)
+        allow(Delayed::Job).to receive(:acquire_locked_job, &method(:stub_implementation)).and_return(job)
       end
 
       it "should return true if the digest in the message payload matches the job" do
         subject
-        @block.call(job).should be_truthy
+        expect(@block.call(job)).to be_truthy
       end
 
       it "should return false if the digest in the message payload doesn't match the job" do
         subject
         job.touch(:updated_at)
-        @block.call(job).should be_truthy
+        expect(@block.call(job)).to be_truthy
       end
 
       it "should return true if there is no digest in the payload object" do
-        work.stub(:payload => JSON.dump(JSON.load(payload).merge("delayed_job_digest" => nil)))
+        allow(work).to receive(:payload).and_return(JSON.dump(JSON.load(payload).merge("delayed_job_digest" => nil)))
         subject
-        @block.call(job).should be_truthy
+        expect(@block.call(job)).to be_truthy
       end
 
     end
@@ -721,19 +721,19 @@ describe TomQueue, "once hooked" do
       # A.K.A We have a locked job!
 
       let(:returned_job) { Delayed::Job.find(job.id) }
-      before { Delayed::Job.stub(:acquire_locked_job => returned_job) }
+      before { allow(Delayed::Job).to receive(:acquire_locked_job).and_return(returned_job) }
 
       it "should not ack the message" do
-        work.should_not_receive(:ack!)
+        expect(work).to_not receive(:ack!)
         subject
       end
 
       it "should return the Job object" do
-        subject.should == returned_job
+        expect(subject).to eq(returned_job)
       end
 
       it "should associate the message object with the job" do
-        subject.tomqueue_work.should == work
+        expect(subject.tomqueue_work).to eq(work)
       end
 
     end
@@ -746,23 +746,23 @@ describe TomQueue, "once hooked" do
         job.locked_at = Delayed::Job.db_time_now - 10
         job.locked_by = "foobar"
         job.save!
-        Delayed::Job.stub(:acquire_locked_job => false)
+        allow(Delayed::Job).to receive(:acquire_locked_job).and_return(false)
       end
 
       it "should ack the message" do
-        work.should_receive(:ack!)
+        expect(work).to receive(:ack!)
         subject
       end
 
       it "should publish a notification for after the max-run-time of the job" do
-        Delayed::Job.tomqueue_manager.should_receive(:publish) do |payload, opts|
-          opts[:run_at].to_i.should == job.locked_at.to_i + Delayed::Worker.max_run_time + 1
+        expect(Delayed::Job.tomqueue_manager).to receive(:publish) do |payload, opts|
+          expect(opts[:run_at].to_i).to eq(job.locked_at.to_i + Delayed::Worker.max_run_time + 1)
         end
         subject
       end
 
       it "should return nil" do
-        subject.should be_nil
+        expect(subject).to be_nil
       end
 
     end
@@ -771,15 +771,15 @@ describe TomQueue, "once hooked" do
       # A.K.A The job doesn't exist anymore!
       #  - we're done!
 
-      before { Delayed::Job.stub(:acquire_locked_job => nil) }
+      before { allow(Delayed::Job).to receive(:acquire_locked_job).and_return(nil) }
 
       it "should ack the message" do
-        work.should_receive(:ack!)
+        expect(work).to receive(:ack!)
         subject
       end
 
       it "should return nil" do
-        subject.should be_nil
+        expect(subject).to be_nil
       end
 
     end
@@ -788,11 +788,11 @@ describe TomQueue, "once hooked" do
       let(:work) { double("Work", :payload => payload, :nack! => nil) }
 
       before do
-        Delayed::Job.tomqueue_manager.stub(:pop).and_raise(SignalException.new("QUIT"))
+        allow(Delayed::Job.tomqueue_manager).to receive(:pop).and_raise(SignalException.new("QUIT"))
       end
 
       it "should return nil" do
-        subject.should be_nil
+        expect(subject).to be_nil
       end
     end
 
@@ -800,7 +800,7 @@ describe TomQueue, "once hooked" do
       let(:work) { double("Work", :payload => payload, :nack! => nil) }
 
       before do
-        Delayed::Job.tomqueue_manager.stub(:pop).and_raise(Exception)
+        allow(Delayed::Job.tomqueue_manager).to receive(:pop).and_raise(Exception)
       end
 
       it "should raise exception" do
@@ -812,16 +812,16 @@ describe TomQueue, "once hooked" do
       let(:work) { double("Work", :payload => payload, :nack! => nil) }
 
       before do
-        Delayed::Job.stub(:acquire_locked_job).and_raise(SignalException.new("QUIT"))
+        allow(Delayed::Job).to receive(:acquire_locked_job).and_raise(SignalException.new("QUIT"))
       end
 
       it "should nack the work" do
-        work.should_receive(:nack!)
+        expect(work).to receive(:nack!)
         subject
       end
 
       it "should return nil" do
-        subject.should be_nil
+        expect(subject).to be_nil
       end
     end
 
@@ -829,11 +829,11 @@ describe TomQueue, "once hooked" do
       let(:work) { double("Work", :payload => payload, :nack! => nil) }
 
       before do
-        Delayed::Job.stub(:acquire_locked_job).and_raise(Exception)
+        expect(Delayed::Job).to receive(:acquire_locked_job).and_raise(Exception)
       end
 
       it "should nack the work" do
-        work.should_receive(:nack!)
+        expect(work).to receive(:nack!)
         begin
           subject
         rescue Exception
@@ -852,7 +852,7 @@ describe TomQueue, "once hooked" do
     let(:job) { Delayed::Job.create!(:payload_object=>payload) }
 
     it "should perform the job" do
-      payload.should_receive(:perform)
+      expect(payload).to receive(:perform)
       job.invoke_job
     end
 

--- a/spec/tom_queue/external_consumer_integration_spec.rb
+++ b/spec/tom_queue/external_consumer_integration_spec.rb
@@ -51,19 +51,19 @@ describe "External consumers" do
     end
 
     it "should call the init and perform methods the consumer" do
-      trace.map { |a| a[0] }.should == [:init, :perform]
+      expect(trace.map { |a| a[0] }).to eq [:init, :perform]
     end
 
     it "should call the init method with the payload and headers" do
       trace.first.tap do |method, payload, headers|
-        method.should == :init
-        payload.should == 'message'
-        headers.should be_a(Hash)
+        expect(method).to eq :init
+        expect(payload).to eq 'message'
+        expect(headers).to be_a(Hash)
       end
     end
 
     it "should have serialized the class so ivars from init are available during the perform call" do
-      trace.last.should == [:perform, 'message']
+      expect(trace.last).to eq [:perform, 'message']
     end
   end
 
@@ -88,14 +88,14 @@ describe "External consumers" do
 
     it "should call the block attached to the bind_exchange call" do
       subject
-      trace.first.first.should == :bind_block
+      expect(trace.first.first).to eq :bind_block
     end
 
     it "should pass the TomQueue::Work object to the block" do
       subject
       trace.first.last.tap do |work|
-        work.should be_a(TomQueue::Work)
-        work.payload.should == 'message'
+        expect(work).to be_a(TomQueue::Work)
+        expect(work.payload).to eq 'message'
       end
     end
 
@@ -124,17 +124,17 @@ describe "External consumers" do
 
       it "should call the bind block, which calls the init and defers the perform call" do
         subject
-        trace.map { |a| a[0] }.should == [:bind_block, :init, :job_performed]
+        expect(trace.map { |a| a[0] }).to eq [:bind_block, :init, :job_performed]
       end
 
       it "should be init'd directly with the custom arguments" do
         subject
-        trace[1].last.should == 'custom-arg'
+        expect(trace[1].last).to eq 'custom-arg'
       end
 
       it "should perform the Delayed::Job" do
         subject
-        trace.last.should == [:job_performed]
+        expect(trace.last).to eq [:job_performed]
       end
 
     end
@@ -149,7 +149,7 @@ describe "External consumers" do
     end
     consumer_class.producer.publish('message')
     subject
-    trace.last[1].response.routing_key.should eq "my.key"
+    expect(trace.last[1].response.routing_key).to eq "my.key"
   end
 
   it "overrides the configured routing key through to the exchange on publication" do
@@ -160,7 +160,7 @@ describe "External consumers" do
     end
     consumer_class.producer.publish('message', :routing_key => "better.key")
     subject
-    trace.last[1].response.routing_key.should eq "better.key"
+    expect(trace.last[1].response.routing_key).to eq "better.key"
   end
 
   it "matches any routing key by default on message publication" do
@@ -175,9 +175,9 @@ describe "External consumers" do
     Delayed::Worker.new.work_off(2)
     consumer_class.producer.publish('message')
     Delayed::Worker.new.work_off(2)
-    trace.should include [:routing_key, "good.key"]
-    trace.should include [:routing_key, "better.key"]
-    trace.should include [:routing_key, ""]
+    expect(trace).to include [:routing_key, "good.key"]
+    expect(trace).to include [:routing_key, "better.key"]
+    expect(trace).to include [:routing_key, ""]
   end
 
 

--- a/spec/tom_queue/helper.rb
+++ b/spec/tom_queue/helper.rb
@@ -77,7 +77,17 @@ RSpec.configure do |r|
 end
 
 def unacked_message_count(priority)
-  queue_name = Delayed::Job.tomqueue_manager.queues[priority].name
-  response = RestClient.get("http://guest:guest@localhost:15672/api/queues/test/#{queue_name}", :accept => :json)
-  JSON.parse(response)["messages_unacknowledged"]
+  queue_name = Delayed::Job.tomqueue_manager.priorities.find { |p| p.name == priority }.queue.name
+  response = {}
+  attempts = 0
+  # Occasionally, the API response doesn't contain the message_unacknowledged key, so if this happens
+  # we keep trying until it appears.
+  until response.keys.include?('messages_unacknowledged')
+    sleep(2 ** attempts / 10.0) if attempts > 0
+    raise "Failed to retrieve messages_unacknowledged from RabbitMQ for queue #{queue_name}" if attempts >= 6
+    attempts += 1
+    response = JSON.parse(RestClient.get("http://guest:guest@localhost:15672/api/queues/test/#{queue_name}", :accept => :json))
+  end
+
+  response["messages_unacknowledged"]
 end

--- a/spec/tom_queue/helper.rb
+++ b/spec/tom_queue/helper.rb
@@ -22,6 +22,18 @@ end
 RSpec.configure do |r|
 
   r.before do
+    # Some tests mess around with these, so let's reset each time
+    TomQueue::QueueManager.poll_interval = 10.0
+    TomQueue::QueueManager.priority_consumer_filter = lambda { |p| true }
+    TomQueue::QueueManager.priorities = [
+      TomQueue::HIGH_PRIORITY, 
+      TomQueue::NORMAL_PRIORITY,
+      TomQueue::LOW_PRIORITY,
+      TomQueue::BULK_PRIORITY
+    ]
+  end
+
+  r.before do
     TomQueue.exception_reporter = Class.new do
       def notify(exception)
         puts "Exception reported: #{exception.inspect}"

--- a/spec/tom_queue/logging_helper_spec.rb
+++ b/spec/tom_queue/logging_helper_spec.rb
@@ -18,42 +18,42 @@ describe TomQueue::LoggingHelper do
 
     it "should emit a debug message passed as an argument" do
       debug "Simple to compute"
-      output.should =~ /^D.+Simple to compute$/
+      expect(output).to be =~ /^D.+Simple to compute$/
     end
 
     it "should emit an info message passed as an argument" do
       info "Simple to compute"
-      output.should =~ /^I.+Simple to compute$/
+      expect(output).to be =~ /^I.+Simple to compute$/
     end
 
     it "should emit a warning message passed as an argument" do
       warn "Simple to compute"
-      output.should =~ /^W.+Simple to compute$/
+      expect(output).to be =~ /^W.+Simple to compute$/
     end
 
     it "should emit an error message passed as an argument" do
       error "Simple to compute"
-      output.should =~ /^E.+Simple to compute$/
+      expect(output).to be =~ /^E.+Simple to compute$/
     end
 
     it "should emit a debug message returned from the block" do
       debug { "Expensive to compute" }
-      output.should =~ /^D.+Expensive to compute$/
+      expect(output).to be =~ /^D.+Expensive to compute$/
     end
 
     it "should emit a info message returned from the block" do
       info { "Expensive to compute" }
-      output.should =~ /^I.+Expensive to compute$/
+      expect(output).to be =~ /^I.+Expensive to compute$/
     end
 
     it "should emit a warn message returned from the block" do
       warn { "Expensive to compute" }
-      output.should =~ /^W.+Expensive to compute$/
+      expect(output).to be =~ /^W.+Expensive to compute$/
     end
 
     it "should emit a error message returned from the block" do
       error { "Expensive to compute" }
-      output.should =~ /^E.+Expensive to compute$/
+      expect(output).to be =~ /^E.+Expensive to compute$/
     end
   end
 
@@ -65,7 +65,7 @@ describe TomQueue::LoggingHelper do
     it "should not yield the debug block" do
       @called = false
       debug { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
   end
 
@@ -77,12 +77,12 @@ describe TomQueue::LoggingHelper do
     it "should not yield the debug block" do
       @called = false
       debug { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
     it "should not yield the info block" do
       @called = false
       info { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
   end
 
@@ -94,17 +94,17 @@ describe TomQueue::LoggingHelper do
     it "should not yield the debug block" do
       @called = false
       debug { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
     it "should not yield the info block" do
       @called = false
       info { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
     it "should not yield the warn block" do
       @called = false
       warn { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
   end
 
@@ -115,22 +115,22 @@ describe TomQueue::LoggingHelper do
     it "should not yield the debug block" do
       @called = false
       debug { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
     it "should not yield the info block" do
       @called = false
       info { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
     it "should not yield the warn block" do
       @called = false
       warn { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
     it "should not yield the error block" do
       @called = false
       error { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
     it "should drop debug messages silently" do
       debug "Message"

--- a/spec/tom_queue/queue_manager_spec.rb
+++ b/spec/tom_queue/queue_manager_spec.rb
@@ -40,7 +40,7 @@ describe TomQueue::QueueManager do
 
   describe "AMQP configuration" do
 
-    TomQueue::PRIORITIES.each do |priority|
+    TomQueue.priorities.each do |priority|
       it "should create a queue for '#{priority}' priority" do
         expect(manager.queue(priority).name).to eq "#{manager.prefix}.balance.#{priority}"
         # Declare the queue, if the parameters don't match the brokers existing channel, then bunny will throw an
@@ -101,8 +101,8 @@ describe TomQueue::QueueManager do
 
     describe "message priorities" do
       it "should have an array of priorities, in the correct order" do
-        expect(TomQueue::PRIORITIES).to be_a(Array)
-        expect(TomQueue::PRIORITIES).to eq [
+        expect(TomQueue.priorities).to be_a(Array)
+        expect(TomQueue.priorities).to eq [
           TomQueue::HIGH_PRIORITY,
           TomQueue::NORMAL_PRIORITY,
           TomQueue::LOW_PRIORITY,
@@ -131,7 +131,7 @@ describe TomQueue::QueueManager do
       end
     end
 
-    TomQueue::PRIORITIES.each do |priority|
+    TomQueue.priorities.each do |priority|
       it "should publish #{priority} priority messages to the single exchange, with routing key set to '#{priority}'" do
         manager.publish("foo", :priority => priority)
         manager.pop.ack!.response.tap do |resp|

--- a/spec/tom_queue/queue_manager_spec.rb
+++ b/spec/tom_queue/queue_manager_spec.rb
@@ -8,33 +8,33 @@ describe TomQueue::QueueManager do
   describe "basic creation" do
 
     it "should be a thing" do
-      defined?(TomQueue::QueueManager).should be_truthy
+      expect(defined?(TomQueue::QueueManager)).to be_truthy
     end
 
     it "should be created with a name-prefix" do
-      manager.prefix.should =~ /^test-[\d.]+$/
+      expect(manager.prefix).to be =~ /^test-[\d.]+$/
     end
 
     it "should default the prefix to TomQueue.default_prefix if available" do
       TomQueue.default_prefix = "test-#{Time.now.to_f}"
-      TomQueue::QueueManager.new.prefix.should == TomQueue.default_prefix
+      expect(TomQueue::QueueManager.new.prefix).to eq TomQueue.default_prefix
     end
 
     it "should raise an ArgumentError if no prefix is specified and no default is available" do
       TomQueue.default_prefix = nil
-      lambda {
+      expect {
         TomQueue::QueueManager.new
-      }.should raise_exception(ArgumentError, /prefix is required/)
+      }.to raise_exception(ArgumentError, /prefix is required/)
     end
 
     it "should use the TomQueue.bunny object" do
-      manager.bunny.should == TomQueue.bunny
+      expect(manager.bunny).to eq TomQueue.bunny
     end
 
     it "should stick to the same bunny object, even if TomQueue.bunny changes" do
       manager
       TomQueue.bunny = "A FAKE RABBIT"
-      manager.bunny.should be_a(Bunny::Session)
+      expect(manager.bunny).to be_a(Bunny::Session)
     end
   end
 
@@ -42,7 +42,7 @@ describe TomQueue::QueueManager do
 
     TomQueue::PRIORITIES.each do |priority|
       it "should create a queue for '#{priority}' priority" do
-        manager.queues[priority].name.should == "#{manager.prefix}.balance.#{priority}"
+        expect(manager.queue(priority).name).to eq "#{manager.prefix}.balance.#{priority}"
         # Declare the queue, if the parameters don't match the brokers existing channel, then bunny will throw an
         # exception.
         channel.queue("#{manager.prefix}.balance.#{priority}", :durable => true, :auto_delete => false, :exclusive => false)
@@ -50,7 +50,7 @@ describe TomQueue::QueueManager do
     end
 
     it "should create a single durable topic exchange" do
-      manager.exchange.name.should == "#{manager.prefix}.work"
+      expect(manager.exchange.name).to eq "#{manager.prefix}.work"
       # Now we declare it again on the broker, which will raise an exception if the parameters don't match
       channel.topic("#{manager.prefix}.work", :durable => true, :auto_delete => false)
     end
@@ -61,17 +61,17 @@ describe TomQueue::QueueManager do
 
     it "should forward the payload directly" do
       manager.publish("foobar")
-      manager.pop.ack!.payload.should == "foobar"
+      expect(manager.pop.ack!.payload).to eq "foobar"
     end
 
     it "should return nil" do
-      manager.publish("some work").should be_nil
+      expect(manager.publish("some work")).to be_nil
     end
 
     it "should raise an exception if the payload isn't a string" do
-      lambda {
+      expect {
         manager.publish({"some" => {"structured_data" => true}})
-      }.should raise_exception(ArgumentError, /must be a string/)
+      }.to raise_exception(ArgumentError, /must be a string/)
     end
 
     describe "deferred execution" do
@@ -81,28 +81,28 @@ describe TomQueue::QueueManager do
       end
 
       it "should throw an ArgumentError exception if :run_at isn't a Time object" do
-        lambda {
+        expect {
           manager.publish("future", :run_at => "around 10pm ?")
-        }.should raise_exception(ArgumentError, /must be a Time object/)
+        }.to raise_exception(ArgumentError, /must be a Time object/)
       end
 
       it "should write the run_at time in the message headers as an ISO-8601 timestamp, with 4-digits of decimal precision" do
         execution_time = Time.now - 1.0
         manager.publish("future", :run_at => execution_time)
-        manager.pop.ack!.headers[:headers]['run_at'].should == execution_time.iso8601(4)
+        expect(manager.pop.ack!.headers[:headers]['run_at']).to eq execution_time.iso8601(4)
       end
 
       it "should default to :run_at the current time" do
         manager.publish("future")
         future_time = Time.now
-        Time.parse(manager.pop.ack!.headers[:headers]['run_at']).should < future_time
+        expect(Time.parse(manager.pop.ack!.headers[:headers]['run_at'])).to be < future_time
       end
     end
 
     describe "message priorities" do
       it "should have an array of priorities, in the correct order" do
-        TomQueue::PRIORITIES.should be_a(Array)
-        TomQueue::PRIORITIES.should == [
+        expect(TomQueue::PRIORITIES).to be_a(Array)
+        expect(TomQueue::PRIORITIES).to eq [
           TomQueue::HIGH_PRIORITY,
           TomQueue::NORMAL_PRIORITY,
           TomQueue::LOW_PRIORITY,
@@ -115,19 +115,19 @@ describe TomQueue::QueueManager do
       end
 
       it "should throw an ArgumentError if an unknown priority value is used" do
-        lambda {
+        expect {
           manager.publish("foobar", :priority => "VERY BLOODY IMPORTANT")
-        }.should raise_exception(ArgumentError, /unknown priority level/)
+        }.to raise_exception(ArgumentError, /unknown priority level/)
       end
 
       it "should write the priority in the message header as 'job_priority'" do
         manager.publish("foobar", :priority => TomQueue::BULK_PRIORITY)
-        manager.pop.ack!.headers[:headers]['job_priority'].should == TomQueue::BULK_PRIORITY
+        expect(manager.pop.ack!.headers[:headers]['job_priority']).to eq TomQueue::BULK_PRIORITY
       end
 
       it "should default to normal priority" do
         manager.publish("foobar")
-        manager.pop.ack!.headers[:headers]['job_priority'].should == TomQueue::NORMAL_PRIORITY
+        expect(manager.pop.ack!.headers[:headers]['job_priority']).to eq TomQueue::NORMAL_PRIORITY
       end
     end
 
@@ -135,8 +135,8 @@ describe TomQueue::QueueManager do
       it "should publish #{priority} priority messages to the single exchange, with routing key set to '#{priority}'" do
         manager.publish("foo", :priority => priority)
         manager.pop.ack!.response.tap do |resp|
-          resp.exchange.should == "#{manager.prefix}.work"
-          resp.routing_key.should == priority
+          expect(resp.exchange).to eq "#{manager.prefix}.work"
+          expect(resp.routing_key).to eq priority
         end
       end
     end
@@ -148,12 +148,12 @@ describe TomQueue::QueueManager do
     describe "when publishing a deferred message" do
       it "should not publish to the normal AMQP queue" do
         manager.publish("work", :run_at => Time.now + 1)
-        manager.queues.values.find { |q| channel.basic_get(q.name).first }.should be_nil
+        expect(manager.priorities.map { |p| p.queue }.find { |q| channel.basic_get(q.name).first }).to be_nil
       end
 
       it "should call #publish_deferred" do
         run_time = Time.now + 1
-        manager.should_receive(:publish_deferred).with("work", run_time, TomQueue::NORMAL_PRIORITY)
+        expect(manager).to receive(:publish_deferred).with("work", run_time, TomQueue::NORMAL_PRIORITY)
         manager.publish("work", :run_at => run_time)
       end
     end
@@ -167,15 +167,15 @@ describe TomQueue::QueueManager do
     end
 
     it "should not have setup a consumer before the first call" do
-      manager.queues.values.each do |queue|
-        queue.status[:consumer_count].should == 0
+      manager.priorities.map { |p| p.queue }.each do |queue|
+        expect(queue.status[:consumer_count]).to eq 0
       end
     end
 
     it "should not leave any running consumers for immediate messages" do
       manager.pop.ack!
-      manager.queues.values.each do |queue|
-        queue.status[:consumer_count].should == 0
+      manager.priorities.map { |p| p.queue }.each do |queue|
+        expect(queue.status[:consumer_count]).to eq 0
       end
     end
 
@@ -184,18 +184,18 @@ describe TomQueue::QueueManager do
       manager.pop.ack!
       Thread.new { sleep 0.1; manager.publish("baz") }
       manager.pop.ack!
-      manager.queues.values.each do |queue|
-        queue.status[:consumer_count].should == 0
+      manager.priorities.map { |p| p.queue }.each do |queue|
+        expect(queue.status[:consumer_count]).to eq 0
       end
     end
 
     it "should return a QueueManager::Work instance" do
-      manager.pop.ack!.should be_a(TomQueue::Work)
+      expect(manager.pop.ack!).to be_a(TomQueue::Work)
     end
 
     it "should return the message at the head of the queue" do
-      manager.pop.ack!.payload.should == "foo"
-      manager.pop.ack!.payload.should == "bar"
+      expect(manager.pop.ack!.payload).to eq "foo"
+      expect(manager.pop.ack!.payload).to eq "bar"
     end
   end
 

--- a/spec/tom_queue/sorted_array_spec.rb
+++ b/spec/tom_queue/sorted_array_spec.rb
@@ -3,7 +3,7 @@ require 'tom_queue/helper'
 describe Range, 'tomqueue_binary_search' do
 
   it "should return nil for an empty range" do
-    (0...0).tomqueue_binary_search.should be_nil
+    expect((0...0).tomqueue_binary_search).to be_nil
   end
 
   describe "for a single item range" do
@@ -13,19 +13,19 @@ describe Range, 'tomqueue_binary_search' do
       range.tomqueue_binary_search do |index|
         @index = index
       end
-      @index.should == 5
+      expect(@index).to eq 5
     end
 
     it "should return 0 if the yield returned -1" do
-      range.tomqueue_binary_search { |index| -1 }.should == 5
+      expect(range.tomqueue_binary_search { |index| -1 }).to eq 5
     end
 
     it "should return 1 if the yield returned +1" do
-      range.tomqueue_binary_search { |index| +1 }.should == 6
+      expect(range.tomqueue_binary_search { |index| +1 }).to eq 6
     end
 
     it "should return 0 if the yield returned 0" do
-      range.tomqueue_binary_search { |index| 0 }.should == 5
+      expect(range.tomqueue_binary_search { |index| 0 }).to eq 5
     end
   end
 
@@ -37,14 +37,14 @@ describe Range, 'tomqueue_binary_search' do
         @index = index
         0
       end
-      @index.should == 7
+      expect(@index).to eq 7
     end
 
     it "should return the lower number if the block returns -1" do
-      range.tomqueue_binary_search { |i| -1 }.should == 7
+      expect(range.tomqueue_binary_search { |i| -1 }).to eq 7
     end
     it "should return the lower number if the block returns 0" do
-      range.tomqueue_binary_search { |i| 0 }.should == 7
+      expect(range.tomqueue_binary_search { |i| 0 }).to eq 7
     end
 
     it "should yield the second number if the block returns +1" do
@@ -56,7 +56,7 @@ describe Range, 'tomqueue_binary_search' do
           0
         end
       end
-      @yielded.should be_truthy
+      expect(@yielded).to be_truthy
     end
   end
 
@@ -68,23 +68,23 @@ describe Range, 'tomqueue_binary_search' do
         @index = index
         0
       end
-      @index.should == 8
+      expect(@index).to eq 8
     end
 
     it "should return the mid-point if the block returns 0" do
-      range.tomqueue_binary_search { |index| 0 }.should == 8
+      expect(range.tomqueue_binary_search { |index| 0 }).to eq 8
     end
 
     it "should recurse to the right on +1" do
       @yielded = []
-      range.tomqueue_binary_search { |index| @yielded << index; 1 }.should == 10
-      @yielded.should == [8,9]
+      expect(range.tomqueue_binary_search { |index| @yielded << index; 1 }).to eq 10
+      expect(@yielded).to eq [8,9]
     end
 
     it "should recurse to the left on -1" do
       @yielded = []
-      range.tomqueue_binary_search { |index| @yielded << index; -1 }.should == 7
-      @yielded.should == [8,7]
+      expect(range.tomqueue_binary_search { |index| @yielded << index; -1 }).to eq 7
+      expect(@yielded).to eq [8,7]
     end
 
   end
@@ -99,11 +99,11 @@ describe Range, 'tomqueue_binary_search' do
     end
 
     it "should get the correct result" do
-      @result.should == value
+      expect(@result).to eq value
     end
 
     it "should yield the correct values" do
-      @yielded.should == [49, 24, 36, 42, 45, 43]
+      expect(@yielded).to eq [49, 24, 36, 42, 45, 43]
     end
   end
 
@@ -117,11 +117,11 @@ describe Range, 'tomqueue_binary_search' do
     end
 
     it "should get the correct result" do
-      @result.should == value
+      expect(@result).to eq value
     end
 
     it "should yield the correct values" do
-      @yielded.should == [1,2,3]
+      expect(@yielded).to eq [1,2,3]
     end
   end
 
@@ -140,7 +140,7 @@ describe TomQueue::SortedArray do
     array << 2
     array << 1
     array << 3
-    array.should == [1,2,3,4,5]
+    expect(array).to eq [1,2,3,4,5]
   end
 
   it "should work for all permutations of insertion" do
@@ -150,11 +150,11 @@ describe TomQueue::SortedArray do
       permutation.each do |i|
         array << i
       end
-      array.should == numbers
+      expect(array).to eq numbers
     end
   end
 
   it "should return itself when inserting" do
-    (array << 3).should == array
+    expect(array << 3).to eq array
   end
 end

--- a/spec/tom_queue/tom_queue_integration_spec.rb
+++ b/spec/tom_queue/tom_queue_integration_spec.rb
@@ -10,7 +10,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
 
   it "should pop a previously published message" do
     manager.publish('some work')
-    manager.pop.payload.should == 'some work'
+    expect(manager.pop.payload).to eq 'some work'
   end
 
   it "should block on #pop until work is published" do
@@ -21,20 +21,20 @@ describe TomQueue::QueueManager, "simple publish / pop" do
       manager.publish('some work')
     end
 
-    consumer.pop.payload.should == 'some work'
+    expect(consumer.pop.payload).to eq 'some work'
   end
 
   it "should work between objects (hello, rabbitmq)" do
     manager.publish "work"
-    consumer.pop.payload.should == "work"
+    expect(consumer.pop.payload).to eq "work"
   end
 
   it "should load-balance work between multiple consumers" do
     manager.publish "foo"
     manager.publish "bar"
 
-    consumer.pop.payload.should == "foo"
-    consumer2.pop.payload.should == "bar"
+    expect(consumer.pop.payload).to eq "foo"
+    expect(consumer2.pop.payload).to eq "bar"
   end
 
   it "should work for more than one message!" do
@@ -50,7 +50,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
       output << a.ack!.payload
       output << b.ack!.payload
     end
-    output.should == input
+    expect(output).to eq input
   end
 
   it "should not drop messages when two different priorities arrive" do
@@ -61,7 +61,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
     out << consumer.pop.ack!.payload
     out << consumer.pop.ack!.payload
     out << consumer.pop.ack!.payload
-    out.sort.should == ["1", "2", "3"]
+    expect(out.sort).to eq ["1", "2", "3"]
   end
 
   it "should handle priority queueing, maintaining per-priority FIFO ordering" do
@@ -70,19 +70,19 @@ describe TomQueue::QueueManager, "simple publish / pop" do
     manager.publish("3", :priority => TomQueue::HIGH_PRIORITY)
 
     # 1,2,3 in the queue - 3 wins as it's highest priority
-    consumer.pop.ack!.payload.should == "3"
+    expect(consumer.pop.ack!.payload).to eq "3"
 
     manager.publish("4", :priority => TomQueue::NORMAL_PRIORITY)
 
     # 1,2,4 in the queue - 2 wins as it's highest (NORMAL) and first in
-    consumer.pop.ack!.payload.should == "2"
+    expect(consumer.pop.ack!.payload).to eq "2"
 
     manager.publish("5", :priority => TomQueue::BULK_PRIORITY)
 
     # 1,4,5 in the queue - we'd expect 4 (highest), 1 (first bulk), 5 (second bulk)
-    consumer.pop.ack!.payload.should == "4"
-    consumer.pop.ack!.payload.should == "1"
-    consumer.pop.ack!.payload.should == "5"
+    expect(consumer.pop.ack!.payload).to eq "4"
+    expect(consumer.pop.ack!.payload).to eq "1"
+    expect(consumer.pop.ack!.payload).to eq "5"
   end
 
   it "should handle priority queueing across two consumers" do
@@ -107,7 +107,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
     order << consumer2.pop.ack!.payload
     order << consumer.pop.ack!.payload
 
-    order.should == ["2","3","4","1","5"]
+    expect(order).to eq ["2","3","4","1","5"]
   end
 
   it "should immediately run a high priority task, when there are lots of bulks" do
@@ -115,21 +115,21 @@ describe TomQueue::QueueManager, "simple publish / pop" do
       manager.publish("stuff #{i}", :priority => TomQueue::BULK_PRIORITY)
     end
 
-    consumer.pop.ack!.payload.should == "stuff 0"
-    consumer2.pop.ack!.payload.should == "stuff 1"
-    consumer.pop.payload.should == "stuff 2"
+    expect(consumer.pop.ack!.payload).to eq "stuff 0"
+    expect(consumer2.pop.ack!.payload).to eq "stuff 1"
+    expect(consumer.pop.payload).to eq "stuff 2"
 
     manager.publish("HIGH1", :priority => TomQueue::HIGH_PRIORITY)
     manager.publish("NORMAL1", :priority => TomQueue::NORMAL_PRIORITY)
     manager.publish("HIGH2", :priority => TomQueue::HIGH_PRIORITY)
     manager.publish("NORMAL2", :priority => TomQueue::NORMAL_PRIORITY)
 
-    consumer.pop.ack!.payload.should == "HIGH1"
-    consumer.pop.ack!.payload.should == "HIGH2"
-    consumer2.pop.ack!.payload.should == "NORMAL1"
-    consumer.pop.ack!.payload.should == "NORMAL2"
+    expect(consumer.pop.ack!.payload).to eq "HIGH1"
+    expect(consumer.pop.ack!.payload).to eq "HIGH2"
+    expect(consumer2.pop.ack!.payload).to eq "NORMAL1"
+    expect(consumer.pop.ack!.payload).to eq "NORMAL2"
 
-    consumer2.pop.ack!.payload.should == "stuff 3"
+    expect(consumer2.pop.ack!.payload).to eq "stuff 3"
   end
 
   it "should allow a message to be deferred for future execution", deferred_work_manager: true do
@@ -137,7 +137,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
     manager.publish("future-work", :run_at => execution_time )
 
     consumer.pop.ack!
-    Time.now.to_f.should > execution_time.to_f
+    expect(Time.now.to_f).to be > execution_time.to_f
   end
 
   describe "slow tests", :timeout => 100 do
@@ -215,7 +215,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
       sink_order = consumers.map { |c| c.work }.flatten.sort.map { |a| a.payload }
 
       # HACK: ignore the ordering as it is flaky, given all the threading going on.
-      Set.new(source_order).should == Set.new(sink_order)
+      expect(Set.new(source_order)).to eq Set.new(sink_order)
     end
 
     it "should be able to drain the queue, block and resume when new work arrives" do
@@ -229,7 +229,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
       end
 
       # This sleep gives the workers enough time to block on the first call to pop
-      sleep 0.1 until manager.queues[TomQueue::NORMAL_PRIORITY].status[:consumer_count] == consumers.size
+      sleep 0.1 until manager.queue(TomQueue::NORMAL_PRIORITY).status[:consumer_count] == consumers.size
 
       # Now publish some work
       50.times do |i|
@@ -239,7 +239,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
       end
 
       # Rough and ready - wait for the queue to empty
-      sleep 0.1 until manager.queues[TomQueue::NORMAL_PRIORITY].status[:message_count] == 0
+      sleep 0.1 until manager.queue(TomQueue::NORMAL_PRIORITY).status[:message_count] == 0
 
       # Now publish some more work
       50.times do |i|
@@ -257,7 +257,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
       sink_order = consumers.map { |c| c.work }.flatten.sort.map { |a| a.payload }
 
       # HACK: ignore the ordering as it is flaky, given all the threading going on.
-      Set.new(sink_order).should == Set.new(source_order)
+      expect(Set.new(sink_order)).to eq Set.new(source_order)
     end
 
     it "should work with lots of deferred work on the queue, and still schedule all messages", deferred_work_manager: true do
@@ -286,11 +286,11 @@ describe TomQueue::QueueManager, "simple publish / pop" do
       consumers.each do |c|
         total_size += c.work.size
         c.work.each do |work|
-          work.received_at.should < (work.run_at + 1.0)
+          expect(work.received_at).to be < (work.run_at + 1.0)
         end
       end
 
-      total_size.should == 200
+      expect(total_size).to eq 200
     end
   end
 

--- a/spec/tom_queue/tom_queue_spec.rb
+++ b/spec/tom_queue/tom_queue_spec.rb
@@ -7,24 +7,24 @@ describe TomQueue, "module functions" do
     module TomQueue
       remove_class_variable(:@@bunny)
     end
-    TomQueue.bunny.should be_nil
+    expect(TomQueue.bunny).to be_nil
   end
 
   it "should store and return a shared bunny instance" do
     new_bunny = double(Bunny)
     TomQueue.bunny = new_bunny
-    TomQueue.bunny.should == new_bunny
+    expect(TomQueue.bunny).to eq new_bunny
   end
 
   it "should default the default_prefix to nil" do
     module TomQueue
       remove_class_variable(:@@default_prefix) if defined?(@@default_prefix)
     end
-    TomQueue.default_prefix.should be_nil
+    expect(TomQueue.default_prefix).to be_nil
   end
   it "should store and return a default_prefix" do
     TomQueue.default_prefix = "foobar"
-    TomQueue.default_prefix.should == "foobar"
+    expect(TomQueue.default_prefix).to eq "foobar"
   end
 
 end

--- a/spec/tom_queue/work_spec.rb
+++ b/spec/tom_queue/work_spec.rb
@@ -6,29 +6,29 @@ describe TomQueue::Work do
   let(:work) { TomQueue::Work.new(manager, :response, {'headers' => true}, 'payload') }
 
   it "should expose the queue manager" do
-    work.manager.should == manager
+    expect(work.manager).to eq manager
   end
   it "should expose the payload" do
-    work.payload.should == 'payload'
+    expect(work.payload).to eq 'payload'
   end
   it "should expose the headers" do
-    work.headers.should == {'headers' => true}
+    expect(work.headers).to eq({'headers' => true})
   end
   it "should expose the amqp response object" do
-    work.response.should == :response
+    expect(work.response).to eq :response
   end
 
   describe "ack! sugar function" do
     before do
-      manager.stub(:ack => nil)
+      allow(manager).to receive(:ack).and_return(nil)
     end
 
     it "should call the queue_manager#ack(self)" do
-      manager.should_receive(:ack)
+      expect(manager).to receive(:ack)
       work.ack!
     end
     it "should return self" do
-      work.ack!.should == work
+      expect(work.ack!).to eq work
     end
   end
 

--- a/test_app/spec/spec_helper.rb
+++ b/test_app/spec/spec_helper.rb
@@ -92,8 +92,8 @@ RSpec.configure do |config|
 
   # Clear the RMQ queues before each spec
   # config.before do
-  #   Delayed::Job.tomqueue_manager.queues.values.map(&:name).each do |name|
-  #     RestClient.delete("#{RMQ_API}/queues/#{AMQP_CONFIG[:vhost]}/#{name}/contents")
+  #   Delayed::Job.tomqueue_manager.priorities.each do |queue| 
+  #     RestClient.delete("#{RMQ_API}/queues/#{AMQP_CONFIG[:vhost]}/#{queue.name}/contents")
   #   end
   # end
 end


### PR DESCRIPTION
The overall intent of this PR is to allow certain priority levels to have a "maximum concurrency", i.e. a maximum number of workers that can consume at any one point.

Firstly, the set of priorities to be customised by the host application, rather than hard-coded to HIGH,NORMAL,LOW and BULK, so we can add specific priority levels corresponding to certain classes of job that we want to control the concurrency of.

In addition, it adds an optional `priority_consumer_filter` proc setting that allows the host application to filter which priorities are actually consumed from in a given process. The intent is that the host application can determine this in the proc without introducing complicated dependencies into TQ itself (ZooKeeper, for example).

