### PR TITLE
Memoize exchange in external consumer

### DIFF
--- a/lib/tom_queue/external_consumer.rb
+++ b/lib/tom_queue/external_consumer.rb
@@ -96,7 +96,7 @@ module TomQueue
 
       # Internal: set up an exchange for publishing messages to
       def exchange
-        Delayed::Job.tomqueue_manager.channel.exchange(@name,
+        @exchange ||= Delayed::Job.tomqueue_manager.channel.exchange(@name,
           :type => @type,
           :auto_delete => @auto_delete,
           :durable => @durable

--- a/lib/tom_queue/version.rb
+++ b/lib/tom_queue/version.rb
@@ -1,3 +1,3 @@
 module TomQueue
-  VERSION = "1.0.3"
+  VERSION = "1.0.4"
 end

--- a/spec/database.yml
+++ b/spec/database.yml
@@ -3,11 +3,13 @@ mysql:
   database: delayed_job_test
   username: root
   encoding: utf8
+  host: 127.0.0.1
 
 postgresql:
   adapter: postgresql
   database: delayed_job_test
   username: postgres
+  host: 127.0.0.1
 
 sqlite3:
   adapter: sqlite3

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -18,7 +18,12 @@ db_adapter ||= 'mysql'
 
 begin
   config = YAML.load(File.read('spec/database.yml'))
-  ActiveRecord::Base.establish_connection config[db_adapter]
+  db_config = config[db_adapter]
+  ActiveRecord::Base.establish_connection(db_config.slice(*%w{adapter host username password}))
+  ActiveRecord::Base.connection.drop_database(db_config["database"]) rescue nil
+  ActiveRecord::Base.connection.create_database(db_config["database"])
+  ActiveRecord::Base.establish_connection(db_config)
+
   ActiveRecord::Base.logger = Delayed::Worker.logger
   ActiveRecord::Base.raise_in_transactional_callbacks = true
   ActiveRecord::Migration.verbose = false

--- a/spec/tom_queue/deferred_work/deferred_work_manager_integration_spec.rb
+++ b/spec/tom_queue/deferred_work/deferred_work_manager_integration_spec.rb
@@ -29,7 +29,7 @@ describe "DeferredWorkManager", "#stop" do
   end
 
   before(:each) do
-    sleep 0.2
+    sleep 0.5
 
     Process.kill("SIGTERM", pid)
     _, @status = Process.waitpid2(pid)

--- a/spec/tom_queue/delayed_job/delayed_job_integration_spec.rb
+++ b/spec/tom_queue/delayed_job/delayed_job_integration_spec.rb
@@ -131,7 +131,7 @@ describe Delayed::Job, "integration spec", :timeout => 10 do
     Delayed::Job.tomqueue_manager.queues[TomQueue::NORMAL_PRIORITY].status[:message_count].should == 1
     Delayed::Worker.new.work_off(1)
 
-    sleep 2
+    sleep 3
     expect(unacked_message_count(TomQueue::NORMAL_PRIORITY)).to eq 0
     Delayed::Job.tomqueue_manager.queues[TomQueue::NORMAL_PRIORITY].status[:message_count].should == 0
   end

--- a/spec/tom_queue/tom_queue_integration_spec.rb
+++ b/spec/tom_queue/tom_queue_integration_spec.rb
@@ -206,6 +206,8 @@ describe TomQueue::QueueManager, "simple publish / pop" do
         manager.publish(work)
       end
 
+      sleep 0.1 until manager.queues[TomQueue::NORMAL_PRIORITY].status[:message_count] == 0
+
       # Now publish a bunch of messages to cause the threads to exit the loop
       consumers.each { |c| c.signal_shutdown }
       consumers.each { |c| c.thread.join }

--- a/spec/tom_queue/tom_queue_integration_spec.rb
+++ b/spec/tom_queue/tom_queue_integration_spec.rb
@@ -248,6 +248,8 @@ describe TomQueue::QueueManager, "simple publish / pop" do
         manager.publish(work)
       end
 
+      sleep 0.1 until manager.queues[TomQueue::NORMAL_PRIORITY].status[:message_count] == 0
+
       # Now publish a bunch of messages to cause the threads to exit the loop
       consumers.each { |c| c.signal_shutdown }
       consumers.each { |c| c.thread.join }

--- a/test_app/config/database.yml
+++ b/test_app/config/database.yml
@@ -2,13 +2,13 @@ development:
   adapter: mysql2
   username: root
   database: tomqueue_dev
-  host: localhost
+  host: 127.0.0.1
   strict: false
 
 test:
   adapter: mysql2
   username: root
   database: tomqueue_test
-  host: localhost
+  host: 127.0.0.1
   strict: false
   pool: 10


### PR DESCRIPTION
Each time we publish a message via an external consumer we are creating a new exchange.  This PR memoizes the exchange in the external consumer so we only create a new exchange once.