### PR TITLE
Ensure channels are open before publishing

### DIFF
--- a/lib/tom_queue/version.rb
+++ b/lib/tom_queue/version.rb
@@ -1,3 +1,3 @@
 module TomQueue
-  VERSION = "1.0.4"
+  VERSION = "1.0.5"
 end

--- a/spec/tom_queue/delayed_job/delayed_job_integration_spec.rb
+++ b/spec/tom_queue/delayed_job/delayed_job_integration_spec.rb
@@ -131,7 +131,7 @@ describe Delayed::Job, "integration spec", :timeout => 10 do
     Delayed::Job.tomqueue_manager.queues[TomQueue::NORMAL_PRIORITY].status[:message_count].should == 1
     Delayed::Worker.new.work_off(1)
 
-    sleep 3
+    sleep 4
     expect(unacked_message_count(TomQueue::NORMAL_PRIORITY)).to eq 0
     Delayed::Job.tomqueue_manager.queues[TomQueue::NORMAL_PRIORITY].status[:message_count].should == 0
   end

--- a/spec/tom_queue/helper.rb
+++ b/spec/tom_queue/helper.rb
@@ -13,7 +13,6 @@ begin
   RestClient.put("http://guest:guest@localhost:15672/api/permissions/test/guest", '{"configure":".*","write":".*","read":".*"}', :content_type => :json, :accept => :json)
   TEST_AMQP_CONFIG = {:host => 'localhost', :vhost => 'test', :user => 'guest', :password => 'guest'}
   TheBunny = Bunny.new(TEST_AMQP_CONFIG)
-  TheBunny.start
 rescue Errno::ECONNREFUSED
   $stderr.puts "\033[1;31mFailed to connect to RabbitMQ, is it running?\033[0m\n\n"
   raise
@@ -34,12 +33,14 @@ RSpec.configure do |r|
 
   # Make sure all tests see the same Bunny instance
   r.before do |test|
-    TomQueue.bunny = TheBunny
   end
 
   r.around do |test|
     TomQueue.default_prefix = "test-#{Time.now.to_f}"
+    TheBunny.start
+    TomQueue.bunny = TheBunny
     test.call
+    TheBunny.stop
   end
 
   r.before do

--- a/spec/tom_queue/queue_manager_spec.rb
+++ b/spec/tom_queue/queue_manager_spec.rb
@@ -32,9 +32,11 @@ describe TomQueue::QueueManager do
     end
 
     it "should stick to the same bunny object, even if TomQueue.bunny changes" do
+      old_bunny = TomQueue.bunny
       manager
       TomQueue.bunny = "A FAKE RABBIT"
       manager.bunny.should be_a(Bunny::Session)
+      TomQueue.bunny = old_bunny
     end
   end
 

--- a/spec/tom_queue/tom_queue_integration_spec.rb
+++ b/spec/tom_queue/tom_queue_integration_spec.rb
@@ -140,6 +140,12 @@ describe TomQueue::QueueManager, "simple publish / pop" do
     Time.now.to_f.should > execution_time.to_f
   end
 
+  it "should reopen closed channels" do
+    manager.channel.close
+    manager.publish('some work')
+    manager.pop.payload.should == 'some work'
+  end
+
   describe "slow tests", :timeout => 100 do
 
     class QueueConsumerThread


### PR DESCRIPTION
Channels can be closed by the server, so we cannot be sure that they are open, just because we haven't closed them ourselves.