### PR TITLE
Pluggable publisher

### DIFF
--- a/lib/tom_queue.rb
+++ b/lib/tom_queue.rb
@@ -1,5 +1,5 @@
 # This is a bit of a library-in-a-library, for the time being
-# 
+#
 # This module manages the interaction with AMQP, handling publishing of
 # work messages, scheduling of work off the AMQP queue, etc.
 #
@@ -8,49 +8,31 @@
 # You probably want to start with TomQueue::QueueManager
 #
 module TomQueue
-  require 'tom_queue/logging_helper'
-  
-  require 'tom_queue/queue_manager'
-  require 'tom_queue/work'
-  
-  require 'tom_queue/deferred_work_set'
-  require 'tom_queue/deferred_work_manager'
+  require "tom_queue/logging_helper"
 
-  require 'tom_queue/external_consumer'
+  require "tom_queue/publisher"
+  require "tom_queue/queue_manager"
+  require "tom_queue/work"
 
-  require 'tom_queue/sorted_array'
+  require "tom_queue/deferred_work_set"
+  require "tom_queue/deferred_work_manager"
 
-  # Public: Sets the bunny instance to use for new QueueManager objects
-  def bunny=(new_bunny)
-    @@bunny = new_bunny
-  end
-  # Public: Returns the current bunny instance
-  #
-  # Returns whatever was passed to TomQueue.bunny = 
-  def bunny
-    defined?(@@bunny) && @@bunny
-  end
-  module_function :bunny, :bunny=
+  require "tom_queue/external_consumer"
 
-  def default_prefix=(new_default_prefix)
-    @@default_prefix = new_default_prefix
-  end
-  def default_prefix
-    defined?(@@default_prefix) && @@default_prefix
-  end
-  module_function :default_prefix=, :default_prefix
+  require "tom_queue/sorted_array"
 
+  mattr_accessor :bunny, :publisher, :default_prefix
+
+  self.publisher = Publisher.new
 
   # Public: Set an object to receive notifications if an internal exception
   # is caught and handled.
   #
-  # IT should be an object that responds to #notify(exception) and should be 
+  # IT should be an object that responds to #notify(exception) and should be
   # thread safe as reported exceptions will be from background threads crashing.
   #
   class << self
     attr_accessor :exception_reporter
     attr_accessor :logger
   end
-
-
 end

--- a/lib/tom_queue/external_consumer.rb
+++ b/lib/tom_queue/external_consumer.rb
@@ -89,17 +89,13 @@ module TomQueue
         message = @encoder.encode(message) if @encoder
         routing_key = options.fetch(:routing_key, @routing_key)
 
-        exchange.publish(message, :routing_key => routing_key)
-      end
-
-      private
-
-      # Internal: set up an exchange for publishing messages to
-      def exchange
-        Delayed::Job.tomqueue_manager.channel.exchange(@name,
-          :type => @type,
-          :auto_delete => @auto_delete,
-          :durable => @durable
+        TomQueue.publisher.publish(
+          Delayed::Job.tomqueue_manager.bunny,
+          exchange_type: @type,
+          exchange_name: @name,
+          exchange_options: { durable: @durable, auto_delete: @auto_delete },
+          message_payload: message,
+          message_options: { routing_key: routing_key }
         )
       end
     end

--- a/lib/tom_queue/publisher.rb
+++ b/lib/tom_queue/publisher.rb
@@ -1,0 +1,8 @@
+module TomQueue
+  class Publisher
+    def publish(bunny, exchange_type:, exchange_name:, exchange_options:, message_payload:, message_options:)
+      exchange = bunny.create_channel.exchange(exchange_name, exchange_options.merge(type: exchange_type))
+      exchange.publish(message_payload, message_options)
+    end
+  end
+end

--- a/lib/tom_queue/version.rb
+++ b/lib/tom_queue/version.rb
@@ -1,3 +1,3 @@
 module TomQueue
-  VERSION = "1.0.6"
+  VERSION = "1.0.7"
 end

--- a/spec/tom_queue/delayed_job/delayed_job_spec.rb
+++ b/spec/tom_queue/delayed_job/delayed_job_spec.rb
@@ -312,8 +312,10 @@ describe TomQueue, "once hooked" do
     it "should call #tomqueue_publish on all DB records" do
       10.times { Delayed::Job.create! }
 
-      Delayed::Job.tomqueue_manager.queues[TomQueue::NORMAL_PRIORITY].purge
       queue = Delayed::Job.tomqueue_manager.queues[TomQueue::NORMAL_PRIORITY]
+      sleep 0.25
+      queue.message_count.should == 10
+      queue.purge
       queue.message_count.should == 0
 
       Delayed::Job.tomqueue_republish
@@ -325,6 +327,7 @@ describe TomQueue, "once hooked" do
       first_ids = 10.times.collect { Delayed::Job.create!.id }
       second_ids = 7.times.collect { Delayed::Job.create!.id }
 
+      sleep 0.25
       Delayed::Job.tomqueue_manager.queues[TomQueue::NORMAL_PRIORITY].purge
       queue = Delayed::Job.tomqueue_manager.queues[TomQueue::NORMAL_PRIORITY]
       queue.message_count.should == 0

--- a/spec/tom_queue/helper.rb
+++ b/spec/tom_queue/helper.rb
@@ -37,6 +37,7 @@ RSpec.configure do |r|
 
   r.around do |test|
     TomQueue.default_prefix = "test-#{Time.now.to_f}"
+    TomQueue.publisher = TomQueue::Publisher.new
     TheBunny.start
     TomQueue.bunny = TheBunny
     test.call

--- a/spec/tom_queue/publisher_spec.rb
+++ b/spec/tom_queue/publisher_spec.rb
@@ -1,0 +1,24 @@
+require 'tom_queue/helper'
+
+describe TomQueue::Publisher do
+
+  subject(:publisher) { TomQueue::Publisher.new }
+
+  let(:channel) { double(:channel) }
+  let(:exchange) { double(:exchange) }
+
+  it "publishes the message to an exchange" do
+    expect(TomQueue.bunny).to receive(:create_channel).and_return(channel)
+    expect(channel).to receive(:exchange).with("myexchange", { foo: :bar, type: :fanout }).and_return(exchange)
+    expect(exchange).to receive(:publish).with("mymessage", { bar: :foo })
+
+    publisher.publish(
+      TomQueue.bunny,
+      exchange_type: :fanout,
+      exchange_name: "myexchange",
+      exchange_options: { foo: :bar },
+      message_payload: "mymessage",
+      message_options: { bar: :foo }
+    )
+  end
+end

--- a/spec/tom_queue/tom_queue_spec.rb
+++ b/spec/tom_queue/tom_queue_spec.rb
@@ -2,29 +2,14 @@ require 'tom_queue/helper'
 
 describe TomQueue, "module functions" do
 
-  it "should not crash if TomQueue.bunny has not been set yet" do
-    # Required since our tests helpfully set TomQueue.bunny for us...
-    module TomQueue
-      remove_class_variable(:@@bunny)
-    end
-    TomQueue.bunny.should be_nil
-  end
-
   it "should store and return a shared bunny instance" do
     new_bunny = double(Bunny)
     TomQueue.bunny = new_bunny
     TomQueue.bunny.should == new_bunny
   end
 
-  it "should default the default_prefix to nil" do
-    module TomQueue
-      remove_class_variable(:@@default_prefix) if defined?(@@default_prefix)
-    end
-    TomQueue.default_prefix.should be_nil
-  end
   it "should store and return a default_prefix" do
     TomQueue.default_prefix = "foobar"
     TomQueue.default_prefix.should == "foobar"
   end
-
 end


### PR DESCRIPTION
Defines `TomQueue.publisher=` and `TomQueue.publisher` methods.

This allows you to define your own publisher, which will handle sending messages to Bunny.

By default uses `TomQueue::Publisher`.