### PR TITLE
Update gemspec to allow activerecord less than 5.2

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -5,3 +5,7 @@ end
 appraise "activerecord-5.0.3" do
   gem "activerecord", "5.0.3"
 end
+
+appraise "activerecord-5.1.6" do
+  gem "activerecord", "5.1.6"
+end

--- a/spec/tom_queue/delayed_job/delayed_job_integration_spec.rb
+++ b/spec/tom_queue/delayed_job/delayed_job_integration_spec.rb
@@ -31,7 +31,7 @@ describe Delayed::Job, "integration spec", :timeout => 10 do
     end
 
     def reschedule_at(time, attempts)
-      time + 0.5
+      time + 2
     end
 
   end
@@ -73,7 +73,7 @@ describe Delayed::Job, "integration spec", :timeout => 10 do
     Benchmark.realtime {
       Delayed::Worker.new.work_off(1).should == [0, 1]
       Delayed::Worker.new.work_off(1).should == [1, 0]
-    }.should > 0.5
+    }.should > 1.0
   end
 
   it "should support run_at", deferred_work_manager: true do

--- a/tom_queue.gemspec
+++ b/tom_queue.gemspec
@@ -3,7 +3,7 @@
 require_relative "lib/tom_queue/version"
 
 Gem::Specification.new do |spec|
-  spec.add_dependency   'activerecord', '>= 4.1', '<= 5.1'
+  spec.add_dependency   'activerecord', '>= 4.1', '< 5.2'
   spec.add_dependency   'delayed_job_active_record'
   spec.add_dependency   'bunny', "~> 2.2"
   spec.authors        = ["Thomas Haggett"]


### PR DESCRIPTION
This is a prerequisite for the rails 5.1 upgrade.

https://github.com/fac/freeagent/pull/15213