### PR TITLE
Bump to version 2.0.0

### DIFF
--- a/lib/tom_queue/version.rb
+++ b/lib/tom_queue/version.rb
@@ -1,3 +1,3 @@
 module TomQueue
-  VERSION = "1.0.7"
+  VERSION = "2.0.0"
 end


### PR DESCRIPTION
* Remove External Consumers
* Don't start consumers when creating a QueueManager