### PR TITLE
Honour original priority for deferred jobs

### DIFF
--- a/lib/tom_queue/queue_manager.rb
+++ b/lib/tom_queue/queue_manager.rb
@@ -178,7 +178,7 @@ module TomQueue
         message_payload: work,
         message_options: {
           routing_key: priority,
-          headers: { job_priority: priority, run_at: run_at.iso8601(4) }
+          headers: { priority: priority, run_at: run_at.iso8601(4) }
         }
       )
     end
@@ -194,7 +194,7 @@ module TomQueue
         message_payload: work,
         message_options: {
           mandatory: true,
-          headers: { job_priority: priority, run_at: run_at.to_f }
+          headers: { priority: priority, run_at: run_at.to_f }
         }
       )
     end

--- a/spec/tom_queue/queue_manager_spec.rb
+++ b/spec/tom_queue/queue_manager_spec.rb
@@ -110,14 +110,14 @@ describe TomQueue::QueueManager do
         }.should raise_exception(ArgumentError, /unknown priority level/)
       end
 
-      it "should write the priority in the message header as 'job_priority'" do
+      it "should write the priority in the message header as 'priority'" do
         manager.publish("foobar", :priority => TomQueue::BULK_PRIORITY)
-        manager.pop.ack!.headers[:headers]['job_priority'].should == TomQueue::BULK_PRIORITY
+        manager.pop.ack!.headers[:headers]['priority'].should == TomQueue::BULK_PRIORITY
       end
 
       it "should default to normal priority" do
         manager.publish("foobar")
-        manager.pop.ack!.headers[:headers]['job_priority'].should == TomQueue::NORMAL_PRIORITY
+        manager.pop.ack!.headers[:headers]['priority'].should == TomQueue::NORMAL_PRIORITY
       end
     end
 

--- a/spec/tom_queue/tom_queue_integration_spec.rb
+++ b/spec/tom_queue/tom_queue_integration_spec.rb
@@ -155,7 +155,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
         message_payload: "future-work",
         message_options: {
           routing_key: "normal",
-          headers: { job_priority: "normal", run_at: run_at.iso8601(4) }
+          headers: { priority: "normal", run_at: run_at.iso8601(4) }
         }
       }
     ]]
@@ -176,7 +176,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
         message_payload: "future-work",
         message_options: {
           mandatory: true,
-          headers: { job_priority: "normal", run_at: run_at.to_f }
+          headers: { priority: "normal", run_at: run_at.to_f }
         }
       }
     ]]


### PR DESCRIPTION
If a job is scheduled for time in the future it will be moved to the
deferred queue and then published back to the Exchange when it is time
to be run.

Unfortunatly when publishing to the Exchange the original
priority of the job isn't honoured resulting in any deferred job being
ending up in the "normal" priority work queue.

This happens because QueueManager.publish expects the priority to be
defined in the "priority" header field however the `publish_*` methods
set "job_priority" instead. Since the "job_priority" header isn't
referenced anywhere else apart from thees functions we change this to
"priority" to make things work as expected.