### PR TITLE
Only pop messages synchronously

### DIFF
--- a/lib/tom_queue/version.rb
+++ b/lib/tom_queue/version.rb
@@ -1,3 +1,3 @@
 module TomQueue
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end

--- a/spec/tom_queue/delayed_job/delayed_job_spec.rb
+++ b/spec/tom_queue/delayed_job/delayed_job_spec.rb
@@ -60,7 +60,7 @@ describe TomQueue, "once hooked" do
 
     it "should return a different value when the object is saved" do
       first_digest = job.tomqueue_digest
-      job.update_attributes(:run_at => Time.now + 10.seconds)
+      job.update!(:run_at => Time.now + 10.seconds)
       job.tomqueue_digest.should_not == first_digest
     end
 
@@ -231,7 +231,7 @@ describe TomQueue, "once hooked" do
 
     it "should not publish a message if the job has a non-nil failed_at" do
       job.should_not_receive(:tomqueue_publish)
-      job.update_attributes(:failed_at => Time.now)
+      job.update!(:failed_at => Time.now)
     end
 
     it "should be called after create when there is no explicit transaction" do

--- a/spec/tom_queue/helper.rb
+++ b/spec/tom_queue/helper.rb
@@ -67,9 +67,9 @@ RSpec.configure do |r|
     Delayed::Job.class_variable_set(:@@tomqueue_manager, nil)
   end
 
-  # All tests should take < 2 seconds !!
+  # All tests should take < 3 seconds !!
   r.around do |test|
-    timeout = self.class.metadata[:timeout] || 2
+    timeout = self.class.metadata[:timeout] || 3
     if timeout == false
       test.call
     else

--- a/spec/tom_queue/tom_queue_integration_spec.rb
+++ b/spec/tom_queue/tom_queue_integration_spec.rb
@@ -284,9 +284,6 @@ describe TomQueue::QueueManager, "simple publish / pop" do
         QueueConsumerThread.new(consumer) { |work| sleep rand(0.5) }.start!
       end
 
-      # This sleep gives the workers enough time to block on the first call to pop
-      sleep 0.1 until manager.queues[TomQueue::NORMAL_PRIORITY].status[:consumer_count] == consumers.size
-
       # Now publish some work
       50.times do |i|
         work = "work #{i}"
@@ -344,7 +341,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
       consumers.each do |c|
         total_size += c.work.size
         c.work.each do |work|
-          work.received_at.should < (work.run_at + 1.0)
+          work.received_at.should < (work.run_at + 2)
         end
       end
 


### PR DESCRIPTION
When reserving a job, first we attempt to synchronously pop a message
from each of the queues in priority order until a message is found. If
no message is found, we would then fallback into the wait_for_message
method. This would then set up a subscriber thread on each queue, block
until a message is received and then shut down all the subscribers.

For some reason, if TimeoutErrors are raised when pulling jobs from the
queues and the queue has been emptied, the consumer threads will never
receive any new messages added to the queue and the worker gets stuck.

We can avoid these issues entirely by only pulling messages from the
queue synchronously in a loop. This removes the wait_for_message method
and adds a loop with a sleep(1) into the sync_poll_queues method, which
should have the same effect.

Fixes https://github.com/fac/freeagent/issues/25025