### PR TITLE
Add executable to boot worker

### DIFF
--- a/bin/tomqueued
+++ b/bin/tomqueued
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+require "./config/environment"
+require "tom_queue/worker"
+
+@worker_options = {
+  :min_priority => ENV['MIN_PRIORITY'],
+  :max_priority => ENV['MAX_PRIORITY'],
+  :queues => (ENV['QUEUES'] || ENV['QUEUE'] || '').split(','),
+  :quiet => ENV['QUIET']
+}
+
+@worker_options[:sleep_delay] = ENV['SLEEP_DELAY'].to_i if ENV['SLEEP_DELAY']
+@worker_options[:read_ahead] = ENV['READ_AHEAD'].to_i if ENV['READ_AHEAD']
+
+TomQueue::Worker.new(@worker_options).start

--- a/lib/tom_queue/worker.rb
+++ b/lib/tom_queue/worker.rb
@@ -1,3 +1,5 @@
+require "delayed_job"
+
 module TomQueue
   class Worker < ::Delayed::Worker
   end

--- a/tom_queue.gemspec
+++ b/tom_queue.gemspec
@@ -9,6 +9,7 @@ Gem::Specification.new do |spec|
   spec.authors        = ["Thomas Haggett"]
   spec.description    = 'AMQP hook for Delayed Job, backed by ActiveRecord'
   spec.email          = ['thomas+gemfiles@freeagent.com']
+  spec.executables   << 'tomqueued'
   spec.files          = %w(tom_queue.gemspec)
   spec.files         += Dir.glob("lib/**/*.rb")
   spec.files         += Dir.glob("spec/**/*")


### PR DESCRIPTION
This commit introduces an executable file we can use to boot up a worker instead of using a rake task.