### PR TITLE
Add forked worker model

### DIFF
--- a/lib/tom_queue/worker_supervisor.rb
+++ b/lib/tom_queue/worker_supervisor.rb
@@ -160,7 +160,7 @@ module TomQueue
     end
 
     def handle_signal_event
-      event = spinner.pop
+      event = spinner.wait_for_message
       case event
       when "CHLD"
         # a child process terminated. Let's remove it from the running processes array so it's started again
@@ -232,7 +232,7 @@ module TomQueue
         @wr.write(message)
       end
 
-      def pop
+      def wait_for_message
         @rd.read(4)
       end
     end

--- a/lib/tom_queue/worker_supervisor.rb
+++ b/lib/tom_queue/worker_supervisor.rb
@@ -1,0 +1,84 @@
+module TomQueue
+  class WorkerSupervisor
+
+    attr_accessor :processes, :before_fork, :after_fork
+
+    def initialize
+      @processes = {}
+      @before_fork = -> { }
+      @after_fork = -> { }
+    end
+
+    def supervise(as:, count: 1, &block)
+      count.times do |i|
+        processes["#{as}#{i + 1}"] = block
+      end
+    end
+
+    def run
+      @stop = false
+      process_ids = {}
+      before_fork.call
+      loop do
+        processes_to_start = (processes.keys - process_ids.values)
+
+        processes_to_start.each do |name|
+          $stdout.puts "Starting '#{name}'..."
+          process_id = fork_process(name)
+          setup_signal_handling_for_process(process_id)
+          process_ids[process_id] = name
+        end
+
+        stopped_process_id, status = wait_for_child_process_to_exit
+
+        if stopped_process_name = process_ids.delete(stopped_process_id)
+          $stderr.puts "#{stopped_process_name} terminated (#{stopped_process_id}) with status #{status.exitstatus}"
+        end
+
+        throttle_loop
+        break if @stop
+      end
+    end
+
+    private
+
+    attr_accessor :stop
+
+    def setup_signal_handling_for_process(process_id)
+      Signal.trap("SIGTERM") do
+        $stdout.puts "trapped signal SIGTERM"
+        begin
+          Process.kill("SIGTERM", process_id)
+        rescue Errno::ESRCH
+          # Child PID already dead
+          $stderr.puts "Tried to kill child process with id #{process_id}, but it was already dead"
+        end
+        raise SignalException, "SIGTERM"
+      end
+    end
+
+    def fork_process(name)
+      fork do
+        execute_child_process(processes[name])
+      end
+    end
+
+    def execute_child_process(process)
+      after_fork.call
+      process.call
+      stop_child_when_process_finishes
+    end
+
+    def stop_child_when_process_finishes
+      exit(0)
+    end
+
+    def wait_for_child_process_to_exit
+      Process.waitpid2
+    end
+
+    def throttle_loop
+      sleep 1
+    end
+  end
+end

--- a/lib/tom_queue/worker_supervisor.rb
+++ b/lib/tom_queue/worker_supervisor.rb
@@ -2,103 +2,157 @@ require 'timeout'
 module TomQueue
   class WorkerSupervisor
 
-    attr_accessor :processes, :before_fork, :after_fork
+    attr_accessor :after_fork, :before_fork, :graceful_timeout, :processes, :loop_throttle
+    attr_reader :currently_running_processes
 
     def initialize
       @processes = {}
+      @currently_running_processes = {}
       @before_fork = -> { }
       @after_fork = -> { }
       @graceful_timeout = 5
+      @loop_throttle = 1
     end
 
+    # Public: Adds a number of processes for the supervisor to control
+    #
+    # as    - The name of the process
+    # count - The number of processes we should fork that execute the block
+    #         passed in
+    # block - The process to supervise
+    #
+    # Examples
+    #
+    #   supervise(as: "worker", count: 3) { TomQueue::Worker.new.start }
+    #   # => 3
+    #
+    #   This adds 3 processes that the supervisor will run and keep alive
+    #   from the #run method
+    #
+    #   supervisor.processes
+    #   #=> {
+    #     "worker1"=>#<Proc:0x00007fa629a41998 (irb):15>,
+    #     "worker2"=>#<Proc:0x00007fa629a41998 (irb):15>,
+    #     "worker3"=>#<Proc:0x00007fa629a41998 (irb):15>
+    #     }
+    #
+    # Returns the number of processes added
     def supervise(as:, count: 1, &block)
       count.times do |i|
         processes["#{as}#{i + 1}"] = block
       end
     end
 
-    attr_accessor :graceful_timeout
 
+    # Public: Starts each process, bringing them back up again if they die.
+    #
+    # Examples
+    #
+    #   supervisor = TomQueue::WorkerSupervisor.new
+    #   supervisor.supervise(as: "worker") do
+    #     loop { p "working..."; sleep 1 }
+    #   end
+    #
+    #   supervisor.supervise(as: "thing that ends") do
+    #     1.upto(3) { |i| p "doing thing #{i}"; sleep 1 }
+    #   end
+    #
+    #   supervisor.run
+    #
+    #   #=>
+    #   Starting 'worker1'...
+    #   Starting 'thing that ends1'...
+    #   "working..."
+    #   "doing thing 1"
+    #   "working..."
+    #   "doing thing 2"
+    #   "working..."
+    #   "doing thing 3"
+    #   "working..."
+    #   thing that ends1 terminated (40099) with status 0
+    #   "working..."
+    #   "working..."
+    #   "working..."
+    #   Starting 'thing that ends1'...
+    #   "doing thing 1"
+    #   "working..."
+    #   "doing thing 2"
+    #   "working..."
+    #   "doing thing 3"
+    #   "working..."
+    #
     def run
-      @queue = Queue.new
+      setup_parent_process_signal_handling
+      self.stop_loop = false
+      self.currently_running_processes = {}
 
-      Signal.trap("TERM") { @queue << "TERM" }
-      Signal.trap("CHLD") { @queue << "CHLD" }
-
-      process_ids = {}
       before_fork.call
-      loop do
-        processes_to_start = (processes.keys - process_ids.values)
 
+      until stop_loop do
         processes_to_start.each do |name|
-          $stdout.puts "Starting '#{name}'..."
-          process_id = fork_process(name)
-          process_ids[process_id] = name
+          fork_process(name)
         end
 
-        event = @queue.pop
-        puts "Got signal event #{event}"
-        case event
-        when "CHLD"
-          stopped_process_id, status = wait_for_child_process_to_exit
-          if stopped_process_name = process_ids.delete(stopped_process_id)
-            $stderr.puts "#{stopped_process_name} terminated (#{stopped_process_id}) with status #{status.exitstatus}"
-          end
-        when "TERM"
-          puts "Shutdown!"
-          break
-        end
+        # wait for signal event (e.g. SIGTERM/SIGCHLD)
+        handle_signal_event
 
         throttle_loop
       end
 
-      puts "cleanly shutting down supervisor process!"
-      process_ids.keys.each do |pid|
-        begin
-          Process.kill("TERM", pid)
-        rescue Errno::ESRCH
-          $stderr.puts "Process already terminated"  
-        end
-      end
-      puts "Waiting #{@graceful_timeout} for processes to exit"
-      process_ids.keys.each do |pid|
-        begin
-          Timeout.timeout(@graceful_timeout) do
-            reaped_pid = Process.waitpid(pid)
-            puts "Process #{reaped_pid} reaped"
-            next
-          end
-        rescue Errno::ECHILD
-          puts "Process doesn't exist - ignoring"
-        rescue Timeout::Error
-          puts "PRocess didn't quit - SIGKILL'ing"
-          Process.kill("KILL", pid)
-          Process.waitpid(pid)
-        end
-      end
+      shut_down_child_processes
+      wait_for_all_child_processes_to_end
     end
 
     private
 
-    attr_accessor :stop
+    attr_accessor :signal_queue, :currently_running_processes, :stop_loop
 
-    def fork_process(name)
-      fork do
-        Signal.trap("TERM", "DEFAULT")
-        Signal.trap("INT", "DEFAULT")
-        Signal.trap("CHLD", "DEFAULT")
-        execute_child_process(processes[name])
-      end
+    def setup_parent_process_signal_handling
+      @signal_queue = Queue.new
+
+      Signal.trap("TERM") { @signal_queue << "TERM" }
+      Signal.trap("CHLD") { @signal_queue << "CHLD" }
     end
 
-    def execute_child_process(process)
-      after_fork.call
-      process.call
-      stop_child_when_process_finishes
+    def processes_to_start
+      processes.keys - currently_running_processes.values
+    end
+
+    def fork_process(name)
+      $stdout.puts "Starting '#{name}'..."
+      process_id = fork do
+        after_fork.call
+        setup_child_process_signal_handling
+        processes[name].call
+      end
+      self.currently_running_processes[process_id] = name
+    end
+
+    def setup_child_process_signal_handling
+      # We don't want the child processes to use the signal handlers defined in the parent process
+      Signal.trap("TERM", "DEFAULT")
+      Signal.trap("INT", "DEFAULT")
+      Signal.trap("CHLD", "DEFAULT")
     end
 
     def stop_child_when_process_finishes
       exit(0)
+    end
+
+    def handle_signal_event
+      signal = signal_queue.pop
+      case signal
+      when /CHLD/
+        # a child process terminated. Let's remove it from the running processes array so it's started again
+        stopped_process_id, status = wait_for_child_process_to_exit
+        if stopped_process_name = currently_running_processes.delete(stopped_process_id)
+          $stderr.puts "#{stopped_process_name} terminated (#{stopped_process_id}) with status #{status.exitstatus}"
+        end
+      when /TERM/
+        # the supervisor received a termination signal. Let's gracefully shut everything down
+        puts "Shutdown!"
+        self.stop_loop = true
+      end
     end
 
     def wait_for_child_process_to_exit
@@ -106,7 +160,35 @@ module TomQueue
     end
 
     def throttle_loop
-      sleep 1
+      sleep loop_throttle
+    end
+
+    def shut_down_child_processes
+      currently_running_processes.keys.each do |pid|
+        begin
+          Process.kill("TERM", pid)
+        rescue Errno::ESRCH
+          $stderr.puts "Process already terminated"
+        end
+      end
+    end
+
+    def wait_for_all_child_processes_to_end
+      currently_running_processes.keys.each do |pid|
+        begin
+          Timeout.timeout(graceful_timeout) do
+            reaped_pid = Process.waitpid(pid)
+            puts "Process #{reaped_pid} reaped"
+            next
+          end
+        rescue Errno::ECHILD
+          puts "Process doesn't exist - ignoring"
+        rescue Timeout::Error
+          puts "Process didn't quit - SIGKILL'ing"
+          Process.kill("KILL", pid)
+          Process.waitpid(pid)
+        end
+      end
     end
   end
 end

--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -12,62 +12,62 @@ Delayed::Worker.logger = Logger.new('/tmp/dj.log')
 ENV['RAILS_ENV'] = 'test'
 
 
-db_adapter, gemfile = ENV["ADAPTER"], ENV["BUNDLE_GEMFILE"]
-db_adapter ||= gemfile && gemfile[%r(gemfiles/(.*?)/)] && $1
-db_adapter ||= 'mysql'
+# db_adapter, gemfile = ENV["ADAPTER"], ENV["BUNDLE_GEMFILE"]
+# db_adapter ||= gemfile && gemfile[%r(gemfiles/(.*?)/)] && $1
+# db_adapter ||= 'mysql'
 
-begin
-  config = YAML.load(File.read('spec/database.yml'))
-  db_config = config[db_adapter]
-  ActiveRecord::Base.establish_connection(db_config.slice(*%w{adapter host username password}))
-  ActiveRecord::Base.connection.drop_database(db_config["database"]) rescue nil
-  ActiveRecord::Base.connection.create_database(db_config["database"], charset: "utf8mb4")
-  ActiveRecord::Base.establish_connection(db_config)
+# begin
+#   config = YAML.load(File.read('spec/database.yml'))
+#   db_config = config[db_adapter]
+#   ActiveRecord::Base.establish_connection(db_config.slice(*%w{adapter host username password}))
+#   ActiveRecord::Base.connection.drop_database(db_config["database"]) rescue nil
+#   ActiveRecord::Base.connection.create_database(db_config["database"], charset: "utf8mb4")
+#   ActiveRecord::Base.establish_connection(db_config)
 
-  ActiveRecord::Base.logger = Delayed::Worker.logger
-  ActiveRecord::Migration.verbose = false
+#   ActiveRecord::Base.logger = Delayed::Worker.logger
+#   ActiveRecord::Migration.verbose = false
 
-  ActiveRecord::Schema.define do
-    create_table :delayed_jobs, :force => true do |table|
-      table.integer  :priority, :default => 0
-      table.integer  :attempts, :default => 0
-      table.text     :handler
-      table.text     :last_error
-      table.datetime :run_at
-      table.datetime :locked_at
-      table.datetime :failed_at
-      table.string   :locked_by
-      table.string   :queue
-      table.timestamps null: false
-    end
+#   ActiveRecord::Schema.define do
+#     create_table :delayed_jobs, :force => true do |table|
+#       table.integer  :priority, :default => 0
+#       table.integer  :attempts, :default => 0
+#       table.text     :handler
+#       table.text     :last_error
+#       table.datetime :run_at
+#       table.datetime :locked_at
+#       table.datetime :failed_at
+#       table.string   :locked_by
+#       table.string   :queue
+#       table.timestamps null: false
+#     end
 
-    add_index :delayed_jobs, [:priority, :run_at], :name => 'delayed_jobs_priority'
+#     add_index :delayed_jobs, [:priority, :run_at], :name => 'delayed_jobs_priority'
 
-    create_table :stories, :primary_key => :story_id, :force => true do |table|
-      table.string :text
-      table.boolean :scoped, :default => true
-    end
-  end
-rescue Mysql2::Error
-  if db_adapter == 'mysql'
-    $stderr.puts "\033[1;31mException when connecting to MySQL, is it running?\033[0m\n\n"
-  end
-  raise
-end
+#     create_table :stories, :primary_key => :story_id, :force => true do |table|
+#       table.string :text
+#       table.boolean :scoped, :default => true
+#     end
+#   end
+# rescue Mysql2::Error
+#   if db_adapter == 'mysql'
+#     $stderr.puts "\033[1;31mException when connecting to MySQL, is it running?\033[0m\n\n"
+#   end
+#   raise
+# end
 
-# Purely useful for test cases...
-class Story < ActiveRecord::Base
-  if ::ActiveRecord::VERSION::MAJOR < 4 && ActiveRecord::VERSION::MINOR < 2
-    set_primary_key :story_id
-  else
-    self.primary_key = :story_id
-  end
-  def tell; text; end
-  def whatever(n, _); tell*n; end
-  default_scope { where(:scoped => true) }
+# # Purely useful for test cases...
+# class Story < ActiveRecord::Base
+#   if ::ActiveRecord::VERSION::MAJOR < 4 && ActiveRecord::VERSION::MINOR < 2
+#     set_primary_key :story_id
+#   else
+#     self.primary_key = :story_id
+#   end
+#   def tell; text; end
+#   def whatever(n, _); tell*n; end
+#   default_scope { where(:scoped => true) }
 
-  handle_asynchronously :whatever
-end
+#   handle_asynchronously :whatever
+# end
 
-# Add this directory so the ActiveSupport autoloading works
-ActiveSupport::Dependencies.autoload_paths << File.dirname(__FILE__)
+# # Add this directory so the ActiveSupport autoloading works
+# ActiveSupport::Dependencies.autoload_paths << File.dirname(__FILE__)

--- a/spec/support/forked_process_helpers.rb
+++ b/spec/support/forked_process_helpers.rb
@@ -1,4 +1,3 @@
-
 class ChildProcessMessage
   include RSpec::Matchers
 
@@ -24,7 +23,7 @@ class ChildProcessMessage
   ensure
     @read.close
   end
-  
+
   def write_in_child_process
     @read.close
     @write.write @message
@@ -79,3 +78,15 @@ class TestForkedProcess
   end
 
 end
+
+Thread.abort_on_exception = true
+class TestChildProcess
+  @@rd, @@wr = IO.pipe
+  def self.run
+    @@wr.close
+
+    Thread.new { loop { exit(1) if @@rd.read.empty? } }
+    yield if block_given?
+  end
+end
+

--- a/spec/support/forked_process_helpers.rb
+++ b/spec/support/forked_process_helpers.rb
@@ -6,7 +6,7 @@ class ChildProcessMessage
     @read, @write = IO.pipe
   end
 
-  # sets a value in the child process to be communicated 
+  # sets a value in the child process to be communicated
   # back to the waiting parent process.
   def set(value)
     @read.close
@@ -31,7 +31,7 @@ class IO
     end
   rescue EOFError
     nil
-  end 
+  end
 end
 
 class TestForkedProcess
@@ -80,7 +80,7 @@ class TestChildProcess
     @@wr.close
     Thread.new do
       loop do
-        if @@rd.read(1).nil? 
+        if @@rd.read(1).nil?
           puts " ** Cleaning up orphaned child #{$$}"
           exit(1)
         end

--- a/spec/support/forked_process_helpers.rb
+++ b/spec/support/forked_process_helpers.rb
@@ -1,0 +1,81 @@
+
+class ChildProcessMessage
+  include RSpec::Matchers
+
+  def initialize(message=nil)
+    @message = message
+    @read, @write = IO.pipe
+  end
+
+  # sets a value in the child process to be communicated 
+  # back to the waiting parent process.
+  def set(value)
+    @read.close
+    @write.write value
+    @write.close
+  end
+
+  # to be called in the parent process, waiting for the child
+  # to set a value
+  def wait(timeout=2)
+    puts "Waiting for child signal"
+    @write.close
+    @read.read_with_timeout(timeout)
+  ensure
+    @read.close
+  end
+  
+  def write_in_child_process
+    @read.close
+    @write.write @message
+    @write.close
+  end
+
+  def expect_message_was_written(times: 1)
+    @write.close
+    expect(@read.gets).to eq @message*times
+    @read.close
+  end
+end
+
+class IO
+  def read_with_timeout(t)
+    rd,_,_ = IO.select([self], nil, nil, t)
+    if rd&.include?(self)
+      self.read_nonblock(1024)
+    else
+      raise "Timeout"
+    end
+  rescue EOFError
+    nil
+  end 
+end
+
+class TestForkedProcess
+  attr_reader :pid
+
+  def initialize(&block)
+    @block = block
+  end
+
+  def start
+    @pid = fork do
+      TestChildProcess.run
+      @block.call
+    end
+  end
+
+  def term
+    Process.kill("SIGTERM", @pid)
+  end
+
+  def kill
+    Process.kill("SIGKILL", @pid)
+  end
+
+  def join
+    _, status = Process.waitpid2(@pid)
+    status
+  end
+
+end

--- a/spec/tom_queue/helper.rb
+++ b/spec/tom_queue/helper.rb
@@ -4,6 +4,21 @@ require 'rest_client'
 require 'tom_queue'
 require 'tom_queue/delayed_job'
 
+require_relative '../support/forked_process_helpers'
+
+#
+# Temporary note:
+#
+# Needs RabbitMQ running with management interface enabled, to get it booted in a docker container:
+#
+#  docker pull rabbitmq:3-management
+#  docker run -d -p 5672:5672 -p 15672:15672 --name rmq-server rabbitmq:3-management
+#
+# To shutdown:
+#
+#  docker kill rmq-server
+#
+
 begin
   begin
     RestClient.delete("http://guest:guest@localhost:15672/api/vhosts/test")

--- a/spec/tom_queue/worker_supervisor_spec.rb
+++ b/spec/tom_queue/worker_supervisor_spec.rb
@@ -91,30 +91,32 @@ describe TomQueue::WorkerSupervisor do
       forked_supervisor.term
     end
 
-    # TODO: See how we can expect a message twice
-    xit "restarts a process if it dies" do
+    it "restarts a process if it dies" do
       worker_message = ChildProcessMessage.new
 
       supervisor.supervise(as: "worker") do
-        worker_message.set "executing process 1"
+        worker_message.set "executing process 1,"
         exit(1)
       end
 
+      supervisor.loop_throttle = 0.1
       forked_supervisor.start
-      expect(worker_message.wait).to eq "executing process 1"
+      sleep 1
+      expect(worker_message.wait.split(",").size).to be_between(3,11)
       forked_supervisor.term
     end
 
-    # TODO: See how we can expect a message once
-    xit "does not try to start a process again if it is not dead" do
-      worker_message = ChildProcessMessage.new#("executing process 1")
+    it "does not try to start a process again if it is not dead" do
+      worker_message = ChildProcessMessage.new
 
       supervisor.supervise(as: "worker") do
         worker_message.set "executing process 1"
         sleep 1 while true
       end
 
+      supervisor.loop_throttle = 0.1
       forked_supervisor.start
+      sleep 1
       expect(worker_message.wait).to eq "executing process 1"
       forked_supervisor.term
     end

--- a/spec/tom_queue/worker_supervisor_spec.rb
+++ b/spec/tom_queue/worker_supervisor_spec.rb
@@ -14,6 +14,9 @@ describe TomQueue::WorkerSupervisor do
   # This hook ensures that any child processes are coupled to this 
   # rspec process by holding open a read file descriptor in a background
   # thread.
+  #
+  # This is in addition to the child processes being linked to the supervisor
+  # process inside WorkerSupervisor.
   before do
     supervisor.after_fork = -> { TestChildProcess.run }
   end

--- a/spec/tom_queue/worker_supervisor_spec.rb
+++ b/spec/tom_queue/worker_supervisor_spec.rb
@@ -11,7 +11,7 @@ describe TomQueue::WorkerSupervisor do
     end
   end
 
-  # This hook ensures that any child processes are coupled to this 
+  # This hook ensures that any child processes are coupled to this
   # rspec process by holding open a read file descriptor in a background
   # thread.
   #
@@ -143,12 +143,12 @@ describe TomQueue::WorkerSupervisor do
       pid = worker_message.wait.match(/started\:(\d+)/)[1].to_i
 
       # don't let it clean up
-      forked_supervisor.kill 
+      forked_supervisor.kill
       forked_supervisor.join
 
-      # getpgid (get process group IDs) should work for any PID on the system and 
+      # getpgid (get process group IDs) should work for any PID on the system and
       # return an answer if the process is running. The worker process should
-      # have been terminated along with the supervisor, so we want it to return 
+      # have been terminated along with the supervisor, so we want it to return
       # an error
       sleep 0.5
       expect { Process.getpgid(pid) }.to raise_exception(Errno::ESRCH)
@@ -257,7 +257,7 @@ describe TomQueue::WorkerSupervisor do
       it "should clean up multiple child processes even if it only receives a single SIGCHLD" do
         signals[:child1_ready]
         signals[:child2_ready]
-    
+
         supervisor.loop_throttle = 0.1
 
         supervisor.supervise(as: "foo1") do

--- a/spec/tom_queue/worker_supervisor_spec.rb
+++ b/spec/tom_queue/worker_supervisor_spec.rb
@@ -1,0 +1,187 @@
+require "pry"
+require 'tom_queue/worker_supervisor'
+
+describe TomQueue::WorkerSupervisor do
+  let(:supervisor) { described_class.new }
+
+  describe "#supervise" do
+    it "creates a process with the right name" do
+      supervisor.supervise(as: "worker") { }
+      expect(supervisor.processes.keys).to include "worker1"
+    end
+
+    it "creates a process with the specified behaviour" do
+      my_proc = -> {}
+      supervisor.supervise(as: "worker", &my_proc)
+      expect(supervisor.processes.values).to include my_proc
+    end
+
+    it "can create multiple processes" do
+      supervisor.supervise(as: "worker", count: 2) { }
+      supervisor.supervise(as: "deferred_worker") { }
+      expect(supervisor.processes.keys).to match_array ["worker1", "worker2", "deferred_worker1"]
+    end
+  end
+
+  describe "#before_fork" do
+    it "assigns the before_fork task" do
+      before_fork_task = -> { }
+      supervisor.before_fork = before_fork_task
+      expect(supervisor.before_fork).to eq before_fork_task
+    end
+  end
+
+  describe "#after_fork" do
+    it "assigns the after_fork task" do
+      after_fork_task = -> { }
+      supervisor.after_fork = after_fork_task
+      expect(supervisor.after_fork).to eq after_fork_task
+    end
+  end
+
+  describe "#run" do
+    let(:process) do
+      -> do
+        loop do
+        end
+      end
+    end
+
+    before { supervisor.supervise(as: "worker", &process) }
+
+    it "runs the before hook" do
+      before_hook_message = ChildProcessMessage.new("before hook")
+      before_fork_task = -> { before_hook_message.write_in_child_process }
+      supervisor.before_fork = before_fork_task
+
+      supervisor_process = fork do
+        supervisor.run
+        exit(0)
+      end
+      sleep 1
+      Process.kill("TERM", supervisor_process)
+      before_hook_message.expect_message_was_written
+    end
+
+    it "runs the after hook" do
+      after_hook_message = ChildProcessMessage.new("executing after fork")
+      after_fork_task = -> { after_hook_message.write_in_child_process }
+      supervisor.after_fork = after_fork_task
+
+      supervisor_process = fork do
+        supervisor.run
+        exit(0)
+      end
+      sleep 1
+      Process.kill("TERM", supervisor_process)
+      after_hook_message.expect_message_was_written
+    end
+
+    it "runs each process" do
+      worker_message = ChildProcessMessage.new("executing process 1")
+      supervisor.supervise(as: "worker") do
+        worker_message.write_in_child_process
+        exit(0)
+      end
+
+      deferred_scheduler_message = ChildProcessMessage.new("executing process 2")
+      supervisor.supervise(as: "deferred scheduler") do
+        deferred_scheduler_message.write_in_child_process
+        exit(0)
+      end
+
+      supervisor_process = fork do
+        supervisor.run
+      end
+
+      sleep 1
+      Process.kill("TERM", supervisor_process)
+
+      worker_message.expect_message_was_written
+      deferred_scheduler_message.expect_message_was_written
+    end
+
+    it "restarts a process if it dies" do
+      worker_message = ChildProcessMessage.new("executing process 1")
+      supervisor.supervise(as: "worker") do
+        worker_message.write_in_child_process
+        exit(1)
+      end
+
+      supervisor_process = fork do
+        supervisor.run
+      end
+
+      # TODO: sleeping is hack
+      sleep 2
+      Process.kill("TERM", supervisor_process)
+
+      worker_message.expect_message_was_written(times: 2)
+    end
+
+    it "does not try to start a process again if it is not dead" do
+      worker_message = ChildProcessMessage.new("executing process 1")
+
+      supervisor.supervise(as: "worker") do
+        worker_message.write_in_child_process
+        loop do
+        end
+      end
+
+      supervisor_process = fork do
+        supervisor.run
+      end
+
+      # TODO: sleeping is hack
+      sleep 2
+      Process.kill("TERM", supervisor_process)
+
+      worker_message.expect_message_was_written(times: 1)
+    end
+
+    context "signal handling" do
+      it "propagates termination signals to child processes" do
+        signal_message = ChildProcessMessage.new("trapped TERM signal")
+        child_process = -> do
+          Signal.trap("SIGTERM") do
+            signal_message.write_in_child_process
+            raise SignalException, "SIGTERM"
+          end
+          loop do
+          end
+        end
+
+        supervisor.supervise(as: "worker", &child_process)
+
+        supervisor_process = fork do
+          supervisor.run
+        end
+        sleep 2
+
+        Process.kill("SIGTERM", supervisor_process)
+        signal_message.expect_message_was_written
+      end
+    end
+
+    class ChildProcessMessage
+      include RSpec::Matchers
+
+      def initialize(message)
+        @message = message
+        @read, @write = IO.pipe
+      end
+
+      def write_in_child_process
+        @read.close
+        @write.write @message
+        @write.close
+      end
+
+      def expect_message_was_written(times: 1)
+        @write.close
+        expect(@read.gets).to eq @message*times
+        @read.close
+      end
+    end
+  end
+end

--- a/spec/tom_queue/worker_supervisor_spec.rb
+++ b/spec/tom_queue/worker_supervisor_spec.rb
@@ -11,6 +11,13 @@ describe TomQueue::WorkerSupervisor do
     end
   end
 
+  # This hook ensures that any child processes are coupled to this 
+  # rspec process by holding open a read file descriptor in a background
+  # thread.
+  before do
+    supervisor.after_fork = -> { TestChildProcess.run }
+  end
+
   describe "#supervise" do
     it "creates a process with the right name" do
       supervisor.supervise(as: "worker") { }
@@ -121,12 +128,31 @@ describe TomQueue::WorkerSupervisor do
       forked_supervisor.term
     end
 
+    it "should tightly couple child processes to the supervisor process" do
+      worker_message = ChildProcessMessage.new
+
+      supervisor.supervise(as: "worker") do
+        worker_message.set "started:#{$$}"
+        sleep 1 while true
+      end
+
+      forked_supervisor.start
+      pid = worker_message.wait.match(/started\:(\d+)/)[1].to_i
+
+      # don't let it clean up
+      forked_supervisor.kill 
+      forked_supervisor.join
+
+      # getpgid (get process group IDs) should work for any PID on the system and 
+      # return an answer if the process is running. The worker process should
+      # have been terminated along with the supervisor, so we want it to return 
+      # an error
+      sleep 0.5
+      expect { Process.getpgid(pid) }.to raise_exception(Errno::ESRCH)
+    end
+
     context "signal handling" do
       let(:signals) { Hash.new { |h,k| h[k] = ChildProcessMessage.new }}
-
-      before do
-        supervisor.after_fork = -> { TestChildProcess.run }
-      end
 
       it "propagates termination signals to child processes" do
         signals[:child_ready]
@@ -199,6 +225,8 @@ describe TomQueue::WorkerSupervisor do
           sleep 1 while true
         end
 
+        # This shouldn't happen, but just in case, we'll simulate a TERM and waitpid
+        # happening before our cleanup
         module ShimProcess
           attr_accessor :wonky_kill
           def kill(signal, pid)
@@ -221,6 +249,46 @@ describe TomQueue::WorkerSupervisor do
         expect(signals[:child_ready].wait).to eq("ready")
         forked_supervisor.term
         expect(forked_supervisor.join.exitstatus).to eq(0)
+      end
+
+      it "should clean up multiple child processes even if it only receives a single SIGCHLD" do
+        signals[:child1_ready]
+        signals[:child2_ready]
+    
+        supervisor.loop_throttle = 0.1
+
+        supervisor.supervise(as: "foo1") do
+          puts "Worker1 startup"
+          signals[:child1_ready].set("ready:#{$$}")
+          sleep 1 while true
+        end
+        supervisor.supervise(as: "foo2") do
+          puts "Worker2 startup"
+          signals[:child2_ready].set("ready:#{$$}")
+          sleep 1 while true
+        end
+
+        forked_supervisor.start
+
+        child1_pid = signals[:child1_ready].wait.match(/\:(\d+)/)[1].to_i
+        child2_pid = signals[:child2_ready].wait.match(/\:(\d+)/)[1].to_i
+
+        # now stall the parent process
+        forked_supervisor.stop
+
+        # kill both child processes
+        Process.kill("KILL", child1_pid)
+        Process.kill("KILL", child2_pid)
+        sleep 0.2
+
+        # resume the parent process
+        forked_supervisor.continue
+
+        new_child1_pid = signals[:child1_ready].wait(5).match(/\:(\d+)/)[1].to_i
+        new_child2_pid = signals[:child2_ready].wait(5).match(/\:(\d+)/)[1].to_i
+
+        expect(new_child1_pid).to_not eq(child1_pid)
+        expect(new_child2_pid).to_not eq(child2_pid)
       end
     end
   end


### PR DESCRIPTION
This PR introduces a forked worker model. Instead of running a worker via the rake task `bundle exec rake jobs:work` we can run a single parent process that manages a pool worker processes (similar to how Unicorn operates). 

This exposes a number of benefits to us, like:

* Better worker memory utilisation as we can pre-load the application before forking
* Minimal fork time means we can recycle workers periodically, avoiding memory utilisation creeping up over time on job workers
* Integrated management of the "deferred worker" process under the same process hierarchy.
* There's a single worker process entry point which better suits containerised operation
* We can tidy up our before_fork and after_fork hooks to be shared across unicorn and DJ.


