### PR TITLE
Update RSpec syntax

### DIFF
--- a/spec/helper.rb
+++ b/spec/helper.rb
@@ -20,7 +20,7 @@ db_config = {
   host: "127.0.0.1",
   database: "delayed_job_test",
   username: "root",
-  password: "root",
+  password: "",
   encoding: "utf8"
 }
 ActiveRecord::Base.establish_connection(db_config.slice(:adapter, :host, :username, :password))

--- a/spec/tom_queue/deferred_work/deferred_work_manager_integration_spec.rb
+++ b/spec/tom_queue/deferred_work/deferred_work_manager_integration_spec.rb
@@ -54,7 +54,7 @@ describe "DeferredWorkManager integration scenarios"  do
       @manager = TomQueue::DeferredWorkManager.new(@prefix)
       TomQueue.exception_reporter = double("ExceptionReporter", :notify => nil)
       @manager.out_manager.publish("work", :run_at => Time.now + 5)
-      @manager.deferred_set.should_receive(:pop).and_raise(RuntimeError, "Yaks Everywhere!")
+      expect(@manager.deferred_set).to receive(:pop).and_raise(RuntimeError, "Yaks Everywhere!")
       @manager.start
     end
 
@@ -63,7 +63,7 @@ describe "DeferredWorkManager integration scenarios"  do
     # we would expect the message to be on the queue again, so this
     # should "just work"
     ch = TomQueue.bunny.create_channel
-    ch.queue("#{@prefix}.work.deferred", durable: true).pop.last.should == "work"
+    expect(ch.queue("#{@prefix}.work.deferred", durable: true).pop.last).to eq("work")
   end
 
   describe "if the AMQP consumer thread crashes", timeout: 4 do
@@ -117,8 +117,8 @@ describe "DeferredWorkManager integration scenarios"  do
       crash!
       @queue_manager.publish("bar", :run_at => Time.now + 2)
 
-      @queue_manager.pop.ack!.payload.should == "foo"
-      @queue_manager.pop.ack!.payload.should == "bar"
+      expect(@queue_manager.pop.ack!.payload).to eq("foo")
+      expect(@queue_manager.pop.ack!.payload).to eq("bar")
     end
 
     it "should re-queue the message once" do

--- a/spec/tom_queue/deferred_work/deferred_work_manager_spec.rb
+++ b/spec/tom_queue/deferred_work/deferred_work_manager_spec.rb
@@ -22,20 +22,20 @@ describe TomQueue::DeferredWorkManager do
     it "should notify something if process crashes" do
       TomQueue.exception_reporter = double("ExceptionReporter", :notify => nil)
       subject.out_manager.publish("work", :run_at => Time.now + 5)
-      subject.deferred_set.should_receive(:pop).and_raise(RuntimeError, "Yaks Everywhere!")
-      TomQueue.exception_reporter.should_receive(:notify) do |exception|
-        exception.should be_a(RuntimeError)
-        exception.message.should == "Yaks Everywhere!"
+      expect(subject.deferred_set).to receive(:pop).and_raise(RuntimeError, "Yaks Everywhere!")
+      expect(TomQueue.exception_reporter).to receive(:notify) do |exception|
+        expect(exception).to be_a(RuntimeError)
+        expect(exception.message).to eq("Yaks Everywhere!")
       end
       subject.start
     end
 
     it "should notify something if consumer thread crashes and re-queue message once" do
       TomQueue.exception_reporter = double("ExceptionReporter", :notify => nil)
-      subject.deferred_set.should_receive(:schedule).twice.and_raise(RuntimeError, "Yaks Everywhere!")
-      TomQueue.exception_reporter.should_receive(:notify) do |exception|
-        exception.should be_a(RuntimeError)
-        exception.message.should == "Yaks Everywhere!"
+      expect(subject.deferred_set).to receive(:schedule).twice.and_raise(RuntimeError, "Yaks Everywhere!")
+      expect(TomQueue.exception_reporter).to receive(:notify) do |exception|
+        expect(exception).to be_a(RuntimeError)
+        expect(exception.message).to eq("Yaks Everywhere!")
       end
 
       subject.out_manager.publish("work", :run_at => Time.now + 5)

--- a/spec/tom_queue/deferred_work/deferred_work_set_spec.rb
+++ b/spec/tom_queue/deferred_work/deferred_work_set_spec.rb
@@ -4,32 +4,32 @@ describe TomQueue::DeferredWorkSet do
   let(:set) { TomQueue::DeferredWorkSet.new }
 
   it "should be creatable" do
-    set.should be_a(TomQueue::DeferredWorkSet)
+    expect(set).to be_a(TomQueue::DeferredWorkSet)
   end
 
   it "should allow work to be scheduled" do
     set.schedule(Time.now + 0.2, "something")
     set.schedule(Time.now + 0.3, "else")
-    set.size.should == 2
+    expect(set.size).to eq(2)
   end
 
   describe "earliest" do
 
     it "should return nil if there is no work in the set" do
-      set.earliest.should be_nil
+      expect(set.earliest).to be_nil
     end
 
     it "should return the only item if there is one item in the set" do
       work = double("Work")
       set.schedule( Time.now + 0.3, work)
-      set.earliest.should == work
+      expect(set.earliest).to eq(work)
     end
 
     it "should return the item in the set with the lowest run_at value" do
       set.schedule( Time.now + 0.2, work1 = double("Work") )
       set.schedule( Time.now + 0.1, work2 = double("Work") )
       set.schedule( Time.now + 0.3, work3 = double("Work") )
-      set.earliest.should == work2
+      expect(set.earliest).to eq(work2)
     end
 
   end
@@ -37,13 +37,13 @@ describe TomQueue::DeferredWorkSet do
   describe "pop" do
 
     it "should return nil when the timeout expires" do
-      set.pop(0.1).should be_nil
+      expect(set.pop(0.1)).to be_nil
     end
 
     it "should block for the timeout value if there is no work in the queue" do
       start_time = Time.now
       set.pop(0.1)
-      Time.now.should > start_time + 0.1
+      expect(Time.now).to be > start_time + 0.1
     end
 
     it "should block until the earliest work in the set" do
@@ -51,32 +51,32 @@ describe TomQueue::DeferredWorkSet do
       set.schedule(start_time + 1.5, "work")
       set.schedule(start_time + 0.1, "work")
       set.pop(10)
-      Time.now.should > start_time + 0.1
-      Time.now.should < start_time + 0.2
+      expect(Time.now).to be > start_time + 0.1
+      expect(Time.now).to be < start_time + 0.2
     end
 
     it "should return immediately if tehre is work scheduled in the past" do
       set.schedule(Time.now - 0.1, "work")
-      set.pop(10).should == "work"
+      expect(set.pop(10)).to eq("work")
     end
 
     it "should have removed the returned work from the set" do
       set.schedule(Time.now - 0.1, "work")
       set.pop(10)
-      set.size.should == 0
+      expect(set.size).to eq(0)
     end
 
     it "should return old work in temporal order" do
       set.schedule(Time.now - 0.1, "work2")
       set.schedule(Time.now - 0.2, "work1")
-      set.pop(10).should == "work1"
-      set.pop(10).should == "work2"
+      expect(set.pop(10)).to eq("work1")
+      expect(set.pop(10)).to eq("work2")
     end
 
     it "should return the earliest work" do
       start_time = Time.now
       set.schedule(start_time + 0.1, "work")
-      set.pop(10).should == "work"
+      expect(set.pop(10)).to eq("work")
     end
 
     it "should block until the earliest work, even if earlier work is added after the block" do
@@ -87,8 +87,8 @@ describe TomQueue::DeferredWorkSet do
       end
       set.schedule(start_time + 1.5, "late")
       set.pop(10)
-      Time.now.should > start_time + 0.2
-      Time.now.should < start_time + 0.3
+      expect(Time.now).to be > start_time + 0.2
+      expect(Time.now).to be < start_time + 0.3
     end
 
     it "should raise an exception if two threads try to block on the same work set" do
@@ -96,9 +96,9 @@ describe TomQueue::DeferredWorkSet do
         set.pop(1)
       end
       sleep 0.1
-      lambda {
+      expect {
         set.pop(1)
-      }.should raise_exception(/another thread is already blocked/)
+      }.to raise_exception(/another thread is already blocked/)
     end
 
     it "should not get deferred items caught outside the cache" do
@@ -106,18 +106,18 @@ describe TomQueue::DeferredWorkSet do
       50.times { |i| set.schedule(start_time+0.1+i*0.001, "bulk") }
       set.schedule(start_time+0.2, "missing")
 
-      50.times { set.pop(1).should == "bulk" }
+      50.times { expect(set.pop(1)).to eq("bulk") }
 
       set.schedule(start_time+0.3, "final")
-      set.pop(1).should == "missing"
-      set.pop(1).should == "final"
+      expect(set.pop(1)).to eq("missing")
+      expect(set.pop(1)).to eq("final")
     end
 
     it "should not delete all elements with the same run_at" do
       the_time = Time.now + 0.1
       set.schedule(the_time, "work-1")
       set.schedule(the_time, "work-2")
-      2.times.collect { set.pop(1) }.sort.should == ["work-1", "work-2"]
+      expect(2.times.collect { set.pop(1) }.sort).to eq(["work-1", "work-2"])
     end
   end
 

--- a/spec/tom_queue/delayed_job/delayed_job_spec.rb
+++ b/spec/tom_queue/delayed_job/delayed_job_spec.rb
@@ -10,40 +10,40 @@ describe TomQueue, "once hooked", dj_hook: true do
     # This makes sure the Delayed::Worker loop spins around on
     # an empty queue to block on TomQueue::QueueManager#pop, so
     # the job will start as soon as we receive a push from RMQ
-    Delayed::Worker.sleep_delay.should == 0
+    expect(Delayed::Worker.sleep_delay).to eq(0)
   end
 
   describe "TomQueue::DelayedJob::Job" do
     it "should use the TomQueue job as the Delayed::Job" do
-      Delayed::Job.should == TomQueue::DelayedJob::Job
+      expect(Delayed::Job).to eq(TomQueue::DelayedJob::Job)
     end
 
     it "should be a subclass of ::Delayed::Backend::ActiveRecord::Job" do
-      TomQueue::DelayedJob::Job.superclass.should == ::Delayed::Backend::ActiveRecord::Job
+      expect(TomQueue::DelayedJob::Job.superclass).to eq(::Delayed::Backend::ActiveRecord::Job)
     end
   end
 
   describe "Delayed::Job.tomqueue_manager" do
     it "should return a TomQueue::QueueManager instance" do
-      Delayed::Job.tomqueue_manager.should be_a(TomQueue::QueueManager)
+      expect(Delayed::Job.tomqueue_manager).to be_a(TomQueue::QueueManager)
     end
 
     it "should have used the default prefix configured" do
-      Delayed::Job.tomqueue_manager.prefix.should == TomQueue.default_prefix
+      expect(Delayed::Job.tomqueue_manager.prefix).to eq(TomQueue.default_prefix)
     end
 
     it "should return the same object on subsequent calls" do
-      Delayed::Job.tomqueue_manager.should == Delayed::Job.tomqueue_manager
+      expect(Delayed::Job.tomqueue_manager).to eq(Delayed::Job.tomqueue_manager)
     end
 
     it "should be reset by rspec (1)" do
       TomQueue.default_prefix = "foo"
-      Delayed::Job.tomqueue_manager.prefix.should == "foo"
+      expect(Delayed::Job.tomqueue_manager.prefix).to eq("foo")
     end
 
     it "should be reset by rspec (2)" do
       TomQueue.default_prefix = "bar"
-      Delayed::Job.tomqueue_manager.prefix.should == "bar"
+      expect(Delayed::Job.tomqueue_manager.prefix).to eq("bar")
     end
   end
 
@@ -61,7 +61,7 @@ describe TomQueue, "once hooked", dj_hook: true do
     it "should return a different value when the object is saved" do
       first_digest = job.tomqueue_digest
       job.update_attributes(:run_at => Time.now + 10.seconds)
-      job.tomqueue_digest.should_not == first_digest
+      expect(job.tomqueue_digest).not_to eq(first_digest)
     end
 
     it "should return the same value, regardless of the time zone (regression)" do
@@ -74,7 +74,7 @@ describe TomQueue, "once hooked", dj_hook: true do
       Time.zone = "Auckland"
 
       job = Delayed::Job.find(job.id)
-      job.tomqueue_digest.should == first_digest
+      expect(job.tomqueue_digest).to eq(first_digest)
 
       Time.zone = old_zone
     end
@@ -85,33 +85,33 @@ describe TomQueue, "once hooked", dj_hook: true do
     let(:payload) { JSON.load(job.tomqueue_payload)}
 
     it "should return a hash" do
-      payload.should be_a(Hash)
+      expect(payload).to be_a(Hash)
     end
 
     it "should contain the job id" do
-      payload['delayed_job_id'].should == job.id
+      expect(payload['delayed_job_id']).to eq(job.id)
     end
 
     it "should contain the current updated_at timestamp (with second-level precision)" do
-      payload['delayed_job_updated_at'].should == job.updated_at.iso8601(0)
+      expect(payload['delayed_job_updated_at']).to eq(job.updated_at.iso8601(0))
     end
 
     it "should contain the digest after saving" do
-      payload['delayed_job_digest'].should == job.tomqueue_digest
+      expect(payload['delayed_job_digest']).to eq(job.tomqueue_digest)
     end
   end
 
   describe "Delayed::Job#tomqueue_publish" do
 
     it "should return nil" do
-      job.tomqueue_publish.should be_nil
+      expect(job.tomqueue_publish).to be_nil
     end
 
     it "should raise an exception if it is called on an unsaved job" do
       TomQueue.exception_reporter = double("SilentExceptionReporter", :notify => nil)
-      lambda {
+      expect {
         Delayed::Job.new.tomqueue_publish
-      }.should raise_exception(ArgumentError, /cannot publish an unsaved Delayed::Job/)
+      }.to raise_exception(ArgumentError, /cannot publish an unsaved Delayed::Job/)
     end
 
     describe "when it is called on a persisted job" do
@@ -120,7 +120,7 @@ describe TomQueue, "once hooked", dj_hook: true do
         job # create the job first so we don't trigger the expectation twice
 
         @called = false
-        Delayed::Job.tomqueue_manager.should_receive(:publish) do |payload, opts|
+        expect(Delayed::Job.tomqueue_manager).to receive(:publish) do |payload, opts|
           @called = true
           @payload = payload
           @opts = opts
@@ -129,7 +129,7 @@ describe TomQueue, "once hooked", dj_hook: true do
 
       it "should call publish on the queue manager" do
         job.tomqueue_publish
-        @called.should be_truthy
+        expect(@called).to be_truthy
       end
 
       describe "job priority" do
@@ -141,7 +141,7 @@ describe TomQueue, "once hooked", dj_hook: true do
         it "should map the priority of the job to the TomQueue priority" do
           new_job.priority = -10
           new_job.save
-          @opts[:priority].should == TomQueue::BULK_PRIORITY
+          expect(@opts[:priority]).to eq(TomQueue::BULK_PRIORITY)
         end
 
         describe "if an unknown priority value is used" do
@@ -151,11 +151,11 @@ describe TomQueue, "once hooked", dj_hook: true do
 
           it "should default the priority to TomQueue::NORMAL_PRIORITY" do
             new_job.save
-            @opts[:priority].should == TomQueue::NORMAL_PRIORITY
+            expect(@opts[:priority]).to eq(TomQueue::NORMAL_PRIORITY)
           end
 
           it "should log a warning" do
-            TomQueue.logger.should_receive(:warn)
+            expect(TomQueue.logger).to receive(:warn)
             new_job.save
           end
         end
@@ -165,24 +165,24 @@ describe TomQueue, "once hooked", dj_hook: true do
 
         it "should use the job's :run_at value by default" do
           job.tomqueue_publish
-          @opts[:run_at].should == job.run_at
+          expect(@opts[:run_at]).to eq(job.run_at)
         end
 
         it "should use the run_at value provided if provided by the caller" do
           the_time = Time.now + 10.seconds
           job.tomqueue_publish(the_time)
-          @opts[:run_at].should == the_time
+          expect(@opts[:run_at]).to eq(the_time)
         end
 
       end
 
       describe "the payload" do
 
-        before { job.stub(:tomqueue_payload => "PAYLOAD") }
+        before { allow(job).to receive(:tomqueue_payload).and_return("PAYLOAD") }
 
         it "should be the return value from #tomqueue_payload" do
           job.tomqueue_publish
-          @payload.should == "PAYLOAD"
+          expect(@payload).to eq("PAYLOAD")
         end
       end
     end
@@ -192,25 +192,25 @@ describe TomQueue, "once hooked", dj_hook: true do
 
       before do
         TomQueue.exception_reporter = double("SilentExceptionReporter", :notify => nil)
-        Delayed::Job.tomqueue_manager.should_receive(:publish).and_raise(exception)
+        expect(Delayed::Job.tomqueue_manager).to receive(:publish).and_raise(exception)
       end
 
       it "should not be raised out to the caller" do
-        lambda { new_job.save }.should_not raise_exception
+        expect { new_job.save }.not_to raise_exception
       end
 
       it "should notify the exception reporter" do
-        TomQueue.exception_reporter.should_receive(:notify).with(exception)
+        expect(TomQueue.exception_reporter).to receive(:notify).with(exception)
         new_job.save
       end
 
       it "should do nothing if the exception reporter is nil" do
         TomQueue.exception_reporter = nil
-        lambda { new_job.save }.should_not raise_exception
+        expect { new_job.save }.not_to raise_exception
       end
 
       it "should log an error message to the log" do
-        TomQueue.logger.should_receive(:error)
+        expect(TomQueue.logger).to receive(:error)
         new_job.save
       end
     end
@@ -221,80 +221,80 @@ describe TomQueue, "once hooked", dj_hook: true do
     it "should allow Mock::ExpectationFailed exceptions to escape the callback" do
       TomQueue.logger = Logger.new("/dev/null")
       TomQueue.exception_reporter = nil
-      Delayed::Job.tomqueue_manager.should_receive(:publish).with("spurious arguments").once
-      lambda {
+      expect(Delayed::Job.tomqueue_manager).to receive(:publish).with("spurious arguments").once
+      expect {
         job.update_attributes(:run_at => Time.now + 5.seconds)
-      }.should raise_exception(RSpec::Mocks::MockExpectationError)
+      }.to raise_exception(RSpec::Mocks::MockExpectationError)
 
       Delayed::Job.tomqueue_manager.publish("spurious arguments") # do this, otherwise it will fail
     end
 
     it "should not publish a message if the job has a non-nil failed_at" do
-      job.should_not_receive(:tomqueue_publish)
+      expect(job).not_to receive(:tomqueue_publish)
       job.update_attributes(:failed_at => Time.now)
     end
 
     it "should be called after create when there is no explicit transaction" do
-      new_job.should_receive(:tomqueue_publish).with(no_args)
+      expect(new_job).to receive(:tomqueue_publish).with(no_args)
       new_job.save!
     end
 
     it "should be called after update when there is no explicit transaction" do
-      job.should_receive(:tomqueue_publish).with(no_args)
+      expect(job).to receive(:tomqueue_publish).with(no_args)
       job.run_at = Time.now + 10.seconds
       job.save!
     end
 
     it "should be called after commit, when a record is saved" do
-      new_job.stub(:tomqueue_publish) { @called = true }
+      allow(new_job).to receive(:tomqueue_publish) { @called = true }
       Delayed::Job.transaction do
         new_job.save!
 
-        @called.should be_nil
+        expect(@called).to be_nil
       end
-      @called.should be_truthy
+      expect(@called).to be_truthy
     end
 
     it "should be called after commit, when a record is updated" do
-      job.stub(:tomqueue_publish) { @called = true }
+      allow(job).to receive(:tomqueue_publish) { @called = true }
       Delayed::Job.transaction do
         job.run_at = Time.now + 10.seconds
         job.save!
-        @called.should be_nil
+        expect(@called).to be_nil
       end
 
-      @called.should be_truthy
+      expect(@called).to be_truthy
     end
 
     it "should not be called when a record is destroyed" do
-      job.should_not_receive(:tomqueue_publish)
+      expect(job).not_to receive(:tomqueue_publish)
       job.destroy
     end
 
     it "should not be called by a destroy in a transaction" do
-      job.should_not_receive(:tomqueue_publish)
+      expect(job).not_to receive(:tomqueue_publish)
       Delayed::Job.transaction { job.destroy }
     end
 
     it "should not be called if the update transaction is rolled back" do
-      job.stub(:tomqueue_publish) { @called = true }
+      allow(job).to receive(:tomqueue_publish) { @called = true }
 
       Delayed::Job.transaction do
         job.run_at = Time.now + 10.seconds
         job.save!
         raise ActiveRecord::Rollback
       end
-      @called.should be_nil
+      expect(@called).to be_nil
     end
 
     it "should not be called if the create transaction is rolled back" do
-      job.should_not_receive(:tomqueue_publish)
+      expect(job).not_to receive(:tomqueue_publish)
 
       Delayed::Job.transaction do
         new_job.save!
         raise ActiveRecord::Rollback
       end
-      @called.should be_nil
+      expect(@called).to be_nil
     end
   end
 
@@ -305,11 +305,11 @@ describe TomQueue, "once hooked", dj_hook: true do
     end
 
     it "should exist" do
-      Delayed::Job.respond_to?(:tomqueue_republish).should be_truthy
+      expect(Delayed::Job.respond_to?(:tomqueue_republish)).to be_truthy
     end
 
     it "should return nil" do
-      Delayed::Job.tomqueue_republish.should be_nil
+      expect(Delayed::Job.tomqueue_republish).to be_nil
     end
 
     it "should call #tomqueue_publish on all DB records" do
@@ -317,13 +317,13 @@ describe TomQueue, "once hooked", dj_hook: true do
 
       queue = Delayed::Job.tomqueue_manager.queues[TomQueue::NORMAL_PRIORITY]
       sleep 0.25
-      queue.message_count.should == 10
+      expect(queue.message_count).to eq(10)
       queue.purge
-      queue.message_count.should == 0
+      expect(queue.message_count).to eq(0)
 
       Delayed::Job.tomqueue_republish
       sleep 0.25
-      queue.message_count.should == 10
+      expect(queue.message_count).to eq(10)
     end
 
     it "should work with ActiveRecord scopes" do
@@ -333,18 +333,18 @@ describe TomQueue, "once hooked", dj_hook: true do
       sleep 0.25
       Delayed::Job.tomqueue_manager.queues[TomQueue::NORMAL_PRIORITY].purge
       queue = Delayed::Job.tomqueue_manager.queues[TomQueue::NORMAL_PRIORITY]
-      queue.message_count.should == 0
+      expect(queue.message_count).to eq(0)
 
       Delayed::Job.where('id IN (?)', second_ids).tomqueue_republish
       sleep 0.25
-      queue.message_count.should == 7
+      expect(queue.message_count).to eq(7)
     end
 
   end
 
   describe "Delayed::Job.acquire_locked_job" do
     let(:time) { Delayed::Job.db_time_now }
-    before { Delayed::Job.stub(:db_time_now => time) }
+    before { allow(Delayed::Job).to receive(:db_time_now).and_return(time) }
 
     let(:job) { Delayed::Job.create! }
     let(:worker) { Delayed::Worker.new }
@@ -358,13 +358,13 @@ describe TomQueue, "once hooked", dj_hook: true do
       before { job.destroy }
 
       it "should return nil" do
-        subject.should be_nil
+        expect(subject).to be_nil
       end
 
       it "should not yield if a block is provided" do
         @block = lambda { |value| @called = true}
         subject
-        @called.should be_nil
+        expect(@called).to be_nil
       end
     end
 
@@ -379,8 +379,9 @@ describe TomQueue, "once hooked", dj_hook: true do
         ActiveRecord::Base.connection.reset!
 
         # Assert we have separate connections
-        second_connection.execute("SELECT connection_id() as id;").first.should_not ==
+        expect(second_connection.execute("SELECT connection_id() as id;").first).not_to eq(
           ActiveRecord::Base.connection.execute("SELECT connection_id() as id;").first
+        )
 
         # This is called in a thread when the transaction is open to query the job, store the response
         # and the time when the response comes back
@@ -408,11 +409,11 @@ describe TomQueue, "once hooked", dj_hook: true do
         @thread.join
 
         # now make sure the parallel thread blocked until the transaction returned
-        @query_returned_at.should > @leaving_transaction_at
+        expect(@query_returned_at).to be > @leaving_transaction_at
 
         # make sure the returned record showed the lock
-        @query_result[0].should_not be_nil
-        @query_result[1].should_not be_nil
+        expect(@query_result[0]).not_to be_nil
+        expect(@query_result[1]).not_to be_nil
       end
 
       describe "when the job is marked as failed" do
@@ -423,20 +424,20 @@ describe TomQueue, "once hooked", dj_hook: true do
         end
 
         it "should return nil" do
-          subject.should be_nil
+          expect(subject).to be_nil
         end
 
         it "should not modify the failed_at value" do
           subject
           job.reload
-          job.failed_at.to_i.should == failed_time.to_i
+          expect(job.failed_at.to_i).to eq(failed_time.to_i)
         end
 
         it "should not lock the job" do
           subject
           job.reload
-          job.locked_by.should be_nil
-          job.locked_at.should be_nil
+          expect(job.locked_by).to be_nil
+          expect(job.locked_at).to be_nil
         end
       end
 
@@ -444,16 +445,16 @@ describe TomQueue, "once hooked", dj_hook: true do
 
         before do
           actual_time = Delayed::Job.db_time_now
-          Delayed::Job.stub(:db_time_now => actual_time - 10)
+          allow(Delayed::Job).to receive(:db_time_now).and_return(actual_time - 10)
         end
 
         it "should return nil" do
-          subject.should be_nil
+          expect(subject).to be_nil
         end
 
         it "should re-post a notification" do
-          Delayed::Job.tomqueue_manager.should_receive(:publish) do |payload, args|
-            args[:run_at].to_i.should == job.run_at.to_i
+          expect(Delayed::Job.tomqueue_manager).to receive(:publish) do |payload, args|
+            expect(args[:run_at].to_i).to eq(job.run_at.to_i)
           end
           subject
         end
@@ -461,8 +462,8 @@ describe TomQueue, "once hooked", dj_hook: true do
         it "should not lock the job" do
           subject
           job.reload
-          job.locked_by.should be_nil
-          job.locked_at.should be_nil
+          expect(job.locked_by).to be_nil
+          expect(job.locked_at).to be_nil
         end
 
       end
@@ -472,26 +473,26 @@ describe TomQueue, "once hooked", dj_hook: true do
         it "should acquire the lock fields on the job" do
           subject
           job.reload
-          job.locked_at.to_i.should == time.to_i
-          job.locked_by.should == worker.name
+          expect(job.locked_at.to_i).to eq(time.to_i)
+          expect(job.locked_by).to eq(worker.name)
         end
 
         it "should return the job object" do
-          subject.should be_a(Delayed::Job)
-          subject.id.should == job.id
+          expect(subject).to be_a(Delayed::Job)
+          expect(subject.id).to eq(job.id)
         end
 
         it "should yield the job to the block if present" do
           @block = lambda { |value| @called = value}
           subject
-          @called.should be_a(Delayed::Job)
-          @called.id.should == job.id
+          expect(@called).to be_a(Delayed::Job)
+          expect(@called.id).to eq(job.id)
         end
 
         it "should not have locked the job when the block is called" do
           @block = lambda { |job| @called = [job.id, job.locked_at, job.locked_by]; true }
           subject
-          @called.should == [job.id, nil, nil]
+          expect(@called).to eq([job.id, nil, nil])
         end
 
         describe "if the supplied block returns true" do
@@ -500,13 +501,13 @@ describe TomQueue, "once hooked", dj_hook: true do
           it "should lock the job" do
             subject
             job.reload
-            job.locked_at.to_i.should == time.to_i
-            job.locked_by.should == worker.name
+            expect(job.locked_at.to_i).to eq(time.to_i)
+            expect(job.locked_by).to eq(worker.name)
           end
 
           it "should return the job" do
-            subject.should be_a(Delayed::Job)
-            subject.id.should == job.id
+            expect(subject).to be_a(Delayed::Job)
+            expect(subject.id).to eq(job.id)
           end
         end
 
@@ -516,12 +517,12 @@ describe TomQueue, "once hooked", dj_hook: true do
           it "should not lock the job" do
             subject
             job.reload
-            job.locked_at.should be_nil
-            job.locked_by.should be_nil
+            expect(job.locked_at).to be_nil
+            expect(job.locked_by).to be_nil
           end
 
           it "should return nil" do
-            subject.should be_nil
+            expect(subject).to be_nil
           end
         end
       end
@@ -538,18 +539,18 @@ describe TomQueue, "once hooked", dj_hook: true do
           @called = false
           @block = lambda { |_| @called = true}
           subject
-          @called.should be_falsy
+          expect(@called).to be_falsy
         end
 
         it "should return false" do
-          subject.should be_falsy
+          expect(subject).to be_falsy
         end
 
         it "should not change the lock" do
           subject
           job.reload
-          job.locked_by.should == @old_locked_by
-          job.locked_at.to_i.should == @old_locked_at.to_i
+          expect(job.locked_by).to eq(@old_locked_by)
+          expect(job.locked_at.to_i).to eq(@old_locked_at.to_i)
         end
 
       end
@@ -562,15 +563,15 @@ describe TomQueue, "once hooked", dj_hook: true do
         end
 
         it "should return the job" do
-          subject.should be_a(Delayed::Job)
-          subject.id.should == job.id
+          expect(subject).to be_a(Delayed::Job)
+          expect(subject.id).to eq(job.id)
         end
 
         it "should update the lock" do
           subject
           job.reload
-          job.locked_at.should_not == @old_locked_at
-          job.locked_by.should_not == @old_locked_by
+          expect(job.locked_at).not_to eq(@old_locked_at)
+          expect(job.locked_by).not_to eq(@old_locked_by)
         end
 
         # This is tricky - if we have a stale lock, the job object
@@ -584,7 +585,7 @@ describe TomQueue, "once hooked", dj_hook: true do
           @called = false
           @block = lambda { |_| @called = true}
           subject
-          @called.should be_falsy
+          expect(@called).to be_falsy
         end
       end
 
@@ -600,11 +601,11 @@ describe TomQueue, "once hooked", dj_hook: true do
     subject { Delayed::Job.reserve(worker) }
 
     before do
-      Delayed::Job.tomqueue_manager.stub(:pop => work)
+      allow(Delayed::Job.tomqueue_manager).to receive(:pop).and_return(work)
     end
 
     it "should call pop on the queue manager" do
-      Delayed::Job.tomqueue_manager.should_receive(:pop)
+      expect(Delayed::Job.tomqueue_manager).to receive(:pop)
 
       subject
     end
@@ -612,8 +613,8 @@ describe TomQueue, "once hooked", dj_hook: true do
     describe "signal handling" do
       it "should allow signal handlers during the pop" do
         Delayed::Worker.raise_signal_exceptions = false
-        Delayed::Job.tomqueue_manager.should_receive(:pop) do
-          Delayed::Worker.raise_signal_exceptions.should be_truthy
+        expect(Delayed::Job.tomqueue_manager).to receive(:pop) do
+          expect(Delayed::Worker.raise_signal_exceptions).to be_truthy
           work
         end
         Delayed::Job.reserve(worker)
@@ -622,17 +623,17 @@ describe TomQueue, "once hooked", dj_hook: true do
       it "should reset the signal handler var after the pop" do
         Delayed::Worker.raise_signal_exceptions = false
         subject
-        Delayed::Worker.raise_signal_exceptions.should == false
+        expect(Delayed::Worker.raise_signal_exceptions).to eq(false)
       end
 
       it "should reset the signal handler var even if it's already true" do
         Delayed::Worker.raise_signal_exceptions = true
         subject
-        Delayed::Worker.raise_signal_exceptions.should == true
+        expect(Delayed::Worker.raise_signal_exceptions).to eq(true)
       end
 
       it "should not allow signal exceptions to escape the function" do
-        Delayed::Job.tomqueue_manager.should_receive(:pop) do
+        expect(Delayed::Job.tomqueue_manager).to receive(:pop) do
           raise SignalException, "INT"
         end
 
@@ -640,7 +641,7 @@ describe TomQueue, "once hooked", dj_hook: true do
       end
 
       it "should allow exceptions to escape the function" do
-        Delayed::Job.tomqueue_manager.should_receive(:pop) do
+        expect(Delayed::Job.tomqueue_manager).to receive(:pop) do
           raise Exception, "Something went wrong"
         end
         expect { subject }.to raise_error(Exception)
@@ -648,16 +649,16 @@ describe TomQueue, "once hooked", dj_hook: true do
     end
 
     describe "if a nil message is popped" do
-      before { Delayed::Job.tomqueue_manager.stub(:pop=>nil) }
+      before { allow(Delayed::Job.tomqueue_manager).to receive(:pop).and_return(nil) }
 
       it "should return nil" do
-        subject.should be_nil
+        expect(subject).to be_nil
       end
 
       it "should sleep for a second to avoid potentially tight loops" do
         start_time = Time.now
         subject
-        (Time.now - start_time).should > 1.0
+        expect(Time.now - start_time).to be > 1.0
       end
     end
 
@@ -668,7 +669,7 @@ describe TomQueue, "once hooked", dj_hook: true do
 
       it "should report an exception" do
         TomQueue.exception_reporter = double("Reporter", :notify => nil)
-        TomQueue.exception_reporter.should_receive(:notify).with(instance_of(JSON::ParserError))
+        expect(TomQueue.exception_reporter).to receive(:notify).with(instance_of(JSON::ParserError))
         subject
       end
 
@@ -678,22 +679,22 @@ describe TomQueue, "once hooked", dj_hook: true do
       end
 
       it "should ack the message" do
-        work.should_receive(:ack!)
+        expect(work).to receive(:ack!)
         subject
       end
 
       it "should log an error" do
-        TomQueue.logger.should_receive(:error)
+        expect(TomQueue.logger).to receive(:error)
         subject
       end
 
       it "should return nil" do
-        subject.should be_nil
+        expect(subject).to be_nil
       end
     end
 
     it "should call acquire_locked_job with the job_id and the worker" do
-      Delayed::Job.should_receive(:acquire_locked_job).with(job.id, worker)
+      expect(Delayed::Job).to receive(:acquire_locked_job).with(job.id, worker)
       subject
     end
 
@@ -701,7 +702,7 @@ describe TomQueue, "once hooked", dj_hook: true do
       def stub_implementation(job_id, worker, &block)
         block.should_not be_nil
       end
-      Delayed::Job.should_receive(:acquire_locked_job, &method(:stub_implementation)).and_return(job)
+      expect(Delayed::Job).to receive(:acquire_locked_job, &method(:stub_implementation)).and_return(job)
       subject
     end
 
@@ -710,24 +711,24 @@ describe TomQueue, "once hooked", dj_hook: true do
         def stub_implementation(job_id, worker, &block)
           @block = block
         end
-        Delayed::Job.should_receive(:acquire_locked_job, &method(:stub_implementation)).and_return(job)
+        expect(Delayed::Job).to receive(:acquire_locked_job, &method(:stub_implementation)).and_return(job)
       end
 
       it "should return true if the digest in the message payload matches the job" do
         subject
-        @block.call(job).should be_truthy
+        expect(@block.call(job)).to be_truthy
       end
 
       it "should return false if the digest in the message payload doesn't match the job" do
         subject
         job.touch(:updated_at)
-        @block.call(job).should be_truthy
+        expect(@block.call(job)).to be_truthy
       end
 
       it "should return true if there is no digest in the payload object" do
-        work.stub(:payload => JSON.dump(JSON.load(payload).merge("delayed_job_digest" => nil)))
+        allow(work).to receive(:payload).and_return(JSON.dump(JSON.load(payload).merge("delayed_job_digest" => nil)))
         subject
-        @block.call(job).should be_truthy
+        expect(@block.call(job)).to be_truthy
       end
 
     end
@@ -736,19 +737,19 @@ describe TomQueue, "once hooked", dj_hook: true do
       # A.K.A We have a locked job!
 
       let(:returned_job) { Delayed::Job.find(job.id) }
-      before { Delayed::Job.stub(:acquire_locked_job => returned_job) }
+      before { allow(Delayed::Job).to receive(:acquire_locked_job).and_return(returned_job) }
 
       it "should not ack the message" do
-        work.should_not_receive(:ack!)
+        expect(work).not_to receive(:ack!)
         subject
       end
 
       it "should return the Job object" do
-        subject.should == returned_job
+        expect(subject).to eq(returned_job)
       end
 
       it "should associate the message object with the job" do
-        subject.tomqueue_work.should == work
+        expect(subject.tomqueue_work).to eq(work)
       end
 
     end
@@ -761,23 +762,23 @@ describe TomQueue, "once hooked", dj_hook: true do
         job.locked_at = Delayed::Job.db_time_now - 10
         job.locked_by = "foobar"
         job.save!
-        Delayed::Job.stub(:acquire_locked_job => false)
+        allow(Delayed::Job).to receive(:acquire_locked_job).and_return(false)
       end
 
       it "should ack the message" do
-        work.should_receive(:ack!)
+        expect(work).to receive(:ack!)
         subject
       end
 
       it "should publish a notification for after the max-run-time of the job" do
-        Delayed::Job.tomqueue_manager.should_receive(:publish) do |payload, opts|
-          opts[:run_at].to_i.should == job.locked_at.to_i + Delayed::Worker.max_run_time + 1
+        expect(Delayed::Job.tomqueue_manager).to receive(:publish) do |payload, opts|
+          expect(opts[:run_at].to_i).to eq(job.locked_at.to_i + Delayed::Worker.max_run_time + 1)
         end
         subject
       end
 
       it "should return nil" do
-        subject.should be_nil
+        expect(subject).to be_nil
       end
 
     end
@@ -786,15 +787,15 @@ describe TomQueue, "once hooked", dj_hook: true do
       # A.K.A The job doesn't exist anymore!
       #  - we're done!
 
-      before { Delayed::Job.stub(:acquire_locked_job => nil) }
+      before { allow(Delayed::Job).to receive(:acquire_locked_job).and_return(nil) }
 
       it "should ack the message" do
-        work.should_receive(:ack!)
+        expect(work).to receive(:ack!)
         subject
       end
 
       it "should return nil" do
-        subject.should be_nil
+        expect(subject).to be_nil
       end
 
     end
@@ -803,11 +804,11 @@ describe TomQueue, "once hooked", dj_hook: true do
       let(:work) { double("Work", :payload => payload, :nack! => nil) }
 
       before do
-        Delayed::Job.tomqueue_manager.stub(:pop).and_raise(SignalException.new("QUIT"))
+        allow(Delayed::Job.tomqueue_manager).to receive(:pop).and_raise(SignalException.new("QUIT"))
       end
 
       it "should return nil" do
-        subject.should be_nil
+        expect(subject).to be_nil
       end
     end
 
@@ -815,7 +816,7 @@ describe TomQueue, "once hooked", dj_hook: true do
       let(:work) { double("Work", :payload => payload, :nack! => nil) }
 
       before do
-        Delayed::Job.tomqueue_manager.stub(:pop).and_raise(Exception)
+        allow(Delayed::Job.tomqueue_manager).to receive(:pop).and_raise(Exception)
       end
 
       it "should raise exception" do
@@ -827,16 +828,16 @@ describe TomQueue, "once hooked", dj_hook: true do
       let(:work) { double("Work", :payload => payload, :nack! => nil) }
 
       before do
-        Delayed::Job.stub(:acquire_locked_job).and_raise(SignalException.new("QUIT"))
+        allow(Delayed::Job).to receive(:acquire_locked_job).and_raise(SignalException.new("QUIT"))
       end
 
       it "should nack the work" do
-        work.should_receive(:nack!)
+        expect(work).to receive(:nack!)
         subject
       end
 
       it "should return nil" do
-        subject.should be_nil
+        expect(subject).to be_nil
       end
     end
 
@@ -844,11 +845,11 @@ describe TomQueue, "once hooked", dj_hook: true do
       let(:work) { double("Work", :payload => payload, :nack! => nil) }
 
       before do
-        Delayed::Job.stub(:acquire_locked_job).and_raise(Exception)
+        allow(Delayed::Job).to receive(:acquire_locked_job).and_raise(Exception)
       end
 
       it "should nack the work" do
-        work.should_receive(:nack!)
+        expect(work).to receive(:nack!)
         begin
           subject
         rescue Exception
@@ -867,7 +868,7 @@ describe TomQueue, "once hooked", dj_hook: true do
     let(:job) { Delayed::Job.create!(:payload_object=>payload) }
 
     it "should perform the job" do
-      payload.should_receive(:perform)
+      expect(payload).to receive(:perform)
       job.invoke_job
     end
 

--- a/spec/tom_queue/logging_helper_spec.rb
+++ b/spec/tom_queue/logging_helper_spec.rb
@@ -18,42 +18,42 @@ describe TomQueue::LoggingHelper do
 
     it "should emit a debug message passed as an argument" do
       debug "Simple to compute"
-      output.should =~ /^D.+Simple to compute$/
+      expect(output).to match(/^D.+Simple to compute$/)
     end
 
     it "should emit an info message passed as an argument" do
       info "Simple to compute"
-      output.should =~ /^I.+Simple to compute$/
+      expect(output).to match(/^I.+Simple to compute$/)
     end
 
     it "should emit a warning message passed as an argument" do
       warn "Simple to compute"
-      output.should =~ /^W.+Simple to compute$/
+      expect(output).to match(/^W.+Simple to compute$/)
     end
 
     it "should emit an error message passed as an argument" do
       error "Simple to compute"
-      output.should =~ /^E.+Simple to compute$/
+      expect(output).to match(/^E.+Simple to compute$/)
     end
 
     it "should emit a debug message returned from the block" do
       debug { "Expensive to compute" }
-      output.should =~ /^D.+Expensive to compute$/
+      expect(output).to match(/^D.+Expensive to compute$/)
     end
 
     it "should emit a info message returned from the block" do
       info { "Expensive to compute" }
-      output.should =~ /^I.+Expensive to compute$/
+      expect(output).to match(/^I.+Expensive to compute$/)
     end
 
     it "should emit a warn message returned from the block" do
       warn { "Expensive to compute" }
-      output.should =~ /^W.+Expensive to compute$/
+      expect(output).to match(/^W.+Expensive to compute$/)
     end
 
     it "should emit a error message returned from the block" do
       error { "Expensive to compute" }
-      output.should =~ /^E.+Expensive to compute$/
+      expect(output).to match(/^E.+Expensive to compute$/)
     end
   end
 
@@ -65,7 +65,7 @@ describe TomQueue::LoggingHelper do
     it "should not yield the debug block" do
       @called = false
       debug { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
   end
 
@@ -77,12 +77,12 @@ describe TomQueue::LoggingHelper do
     it "should not yield the debug block" do
       @called = false
       debug { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
     it "should not yield the info block" do
       @called = false
       info { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
   end
 
@@ -94,17 +94,17 @@ describe TomQueue::LoggingHelper do
     it "should not yield the debug block" do
       @called = false
       debug { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
     it "should not yield the info block" do
       @called = false
       info { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
     it "should not yield the warn block" do
       @called = false
       warn { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
   end
 
@@ -115,22 +115,22 @@ describe TomQueue::LoggingHelper do
     it "should not yield the debug block" do
       @called = false
       debug { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
     it "should not yield the info block" do
       @called = false
       info { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
     it "should not yield the warn block" do
       @called = false
       warn { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
     it "should not yield the error block" do
       @called = false
       error { @called = true }
-      @called.should be_falsy
+      expect(@called).to be_falsy
     end
     it "should drop debug messages silently" do
       debug "Message"

--- a/spec/tom_queue/sorted_array_spec.rb
+++ b/spec/tom_queue/sorted_array_spec.rb
@@ -3,7 +3,7 @@ require 'tom_queue/helper'
 describe Range, 'tomqueue_binary_search' do
 
   it "should return nil for an empty range" do
-    (0...0).tomqueue_binary_search.should be_nil
+    expect((0...0).tomqueue_binary_search).to be_nil
   end
 
   describe "for a single item range" do
@@ -13,19 +13,19 @@ describe Range, 'tomqueue_binary_search' do
       range.tomqueue_binary_search do |index|
         @index = index
       end
-      @index.should == 5
+      expect(@index).to eq(5)
     end
 
     it "should return 0 if the yield returned -1" do
-      range.tomqueue_binary_search { |index| -1 }.should == 5
+      expect(range.tomqueue_binary_search { |index| -1 }).to eq(5)
     end
 
     it "should return 1 if the yield returned +1" do
-      range.tomqueue_binary_search { |index| +1 }.should == 6
+      expect(range.tomqueue_binary_search { |index| +1 }).to eq(6)
     end
 
     it "should return 0 if the yield returned 0" do
-      range.tomqueue_binary_search { |index| 0 }.should == 5
+      expect(range.tomqueue_binary_search { |index| 0 }).to eq(5)
     end
   end
 
@@ -37,14 +37,14 @@ describe Range, 'tomqueue_binary_search' do
         @index = index
         0
       end
-      @index.should == 7
+      expect(@index).to eq(7)
     end
 
     it "should return the lower number if the block returns -1" do
-      range.tomqueue_binary_search { |i| -1 }.should == 7
+      expect(range.tomqueue_binary_search { |i| -1 }).to eq(7)
     end
     it "should return the lower number if the block returns 0" do
-      range.tomqueue_binary_search { |i| 0 }.should == 7
+      expect(range.tomqueue_binary_search { |i| 0 }).to eq(7)
     end
 
     it "should yield the second number if the block returns +1" do
@@ -56,7 +56,7 @@ describe Range, 'tomqueue_binary_search' do
           0
         end
       end
-      @yielded.should be_truthy
+      expect(@yielded).to be_truthy
     end
   end
 
@@ -68,23 +68,23 @@ describe Range, 'tomqueue_binary_search' do
         @index = index
         0
       end
-      @index.should == 8
+      expect(@index).to eq(8)
     end
 
     it "should return the mid-point if the block returns 0" do
-      range.tomqueue_binary_search { |index| 0 }.should == 8
+      expect(range.tomqueue_binary_search { |index| 0 }).to eq(8)
     end
 
     it "should recurse to the right on +1" do
       @yielded = []
-      range.tomqueue_binary_search { |index| @yielded << index; 1 }.should == 10
-      @yielded.should == [8,9]
+      expect(range.tomqueue_binary_search { |index| @yielded << index; 1 }).to eq(10)
+      expect(@yielded).to eq([8,9])
     end
 
     it "should recurse to the left on -1" do
       @yielded = []
-      range.tomqueue_binary_search { |index| @yielded << index; -1 }.should == 7
-      @yielded.should == [8,7]
+      expect(range.tomqueue_binary_search { |index| @yielded << index; -1 }).to eq(7)
+      expect(@yielded).to eq([8,7])
     end
 
   end
@@ -99,11 +99,11 @@ describe Range, 'tomqueue_binary_search' do
     end
 
     it "should get the correct result" do
-      @result.should == value
+      expect(@result).to eq(value)
     end
 
     it "should yield the correct values" do
-      @yielded.should == [49, 24, 36, 42, 45, 43]
+      expect(@yielded).to eq([49, 24, 36, 42, 45, 43])
     end
   end
 
@@ -117,11 +117,11 @@ describe Range, 'tomqueue_binary_search' do
     end
 
     it "should get the correct result" do
-      @result.should == value
+      expect(@result).to eq(value)
     end
 
     it "should yield the correct values" do
-      @yielded.should == [1,2,3]
+      expect(@yielded).to eq([1,2,3])
     end
   end
 
@@ -140,7 +140,7 @@ describe TomQueue::SortedArray do
     array << 2
     array << 1
     array << 3
-    array.should == [1,2,3,4,5]
+    expect(array).to eq([1,2,3,4,5])
   end
 
   it "should work for all permutations of insertion" do
@@ -150,11 +150,11 @@ describe TomQueue::SortedArray do
       permutation.each do |i|
         array << i
       end
-      array.should == numbers
+      expect(array).to eq(numbers)
     end
   end
 
   it "should return itself when inserting" do
-    (array << 3).should == array
+    expect(array << 3).to eq(array)
   end
 end

--- a/spec/tom_queue/tom_queue_integration_spec.rb
+++ b/spec/tom_queue/tom_queue_integration_spec.rb
@@ -10,7 +10,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
 
   it "should pop a previously published message" do
     manager.publish('some work')
-    manager.pop.payload.should == 'some work'
+    expect(manager.pop.payload).to eq('some work')
   end
 
   it "should block on #pop until work is published" do
@@ -21,20 +21,20 @@ describe TomQueue::QueueManager, "simple publish / pop" do
       manager.publish('some work')
     end
 
-    consumer.pop.payload.should == 'some work'
+    expect(consumer.pop.payload).to eq('some work')
   end
 
   it "should work between objects (hello, rabbitmq)" do
     manager.publish "work"
-    consumer.pop.payload.should == "work"
+    expect(consumer.pop.payload).to eq("work")
   end
 
   it "should load-balance work between multiple consumers" do
     manager.publish "foo"
     manager.publish "bar"
 
-    consumer.pop.payload.should == "foo"
-    consumer2.pop.payload.should == "bar"
+    expect(consumer.pop.payload).to eq("foo")
+    expect(consumer2.pop.payload).to eq("bar")
   end
 
   it "should work for more than one message!" do
@@ -50,7 +50,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
       output << a.ack!.payload
       output << b.ack!.payload
     end
-    output.should == input
+    expect(output).to eq(input)
   end
 
   it "should not drop messages when two different priorities arrive" do
@@ -61,7 +61,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
     out << consumer.pop.ack!.payload
     out << consumer.pop.ack!.payload
     out << consumer.pop.ack!.payload
-    out.sort.should == ["1", "2", "3"]
+    expect(out.sort).to eq(["1", "2", "3"])
   end
 
   it "should handle priority queueing, maintaining per-priority FIFO ordering" do
@@ -70,19 +70,19 @@ describe TomQueue::QueueManager, "simple publish / pop" do
     manager.publish("3", :priority => TomQueue::HIGH_PRIORITY)
 
     # 1,2,3 in the queue - 3 wins as it's highest priority
-    consumer.pop.ack!.payload.should == "3"
+    expect(consumer.pop.ack!.payload).to eq("3")
 
     manager.publish("4", :priority => TomQueue::NORMAL_PRIORITY)
 
     # 1,2,4 in the queue - 2 wins as it's highest (NORMAL) and first in
-    consumer.pop.ack!.payload.should == "2"
+    expect(consumer.pop.ack!.payload).to eq("2")
 
     manager.publish("5", :priority => TomQueue::BULK_PRIORITY)
 
     # 1,4,5 in the queue - we'd expect 4 (highest), 1 (first bulk), 5 (second bulk)
-    consumer.pop.ack!.payload.should == "4"
-    consumer.pop.ack!.payload.should == "1"
-    consumer.pop.ack!.payload.should == "5"
+    expect(consumer.pop.ack!.payload).to eq("4")
+    expect(consumer.pop.ack!.payload).to eq("1")
+    expect(consumer.pop.ack!.payload).to eq("5")
   end
 
   it "should handle priority queueing across two consumers" do
@@ -107,7 +107,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
     order << consumer2.pop.ack!.payload
     order << consumer.pop.ack!.payload
 
-    order.should == ["2","3","4","1","5"]
+    expect(order).to eq(["2","3","4","1","5"])
   end
 
   it "should immediately run a high priority task, when there are lots of bulks" do
@@ -115,21 +115,21 @@ describe TomQueue::QueueManager, "simple publish / pop" do
       manager.publish("stuff #{i}", :priority => TomQueue::BULK_PRIORITY)
     end
 
-    consumer.pop.ack!.payload.should == "stuff 0"
-    consumer2.pop.ack!.payload.should == "stuff 1"
-    consumer.pop.payload.should == "stuff 2"
+    expect(consumer.pop.ack!.payload).to eq("stuff 0")
+    expect(consumer2.pop.ack!.payload).to eq("stuff 1")
+    expect(consumer.pop.payload).to eq("stuff 2")
 
     manager.publish("HIGH1", :priority => TomQueue::HIGH_PRIORITY)
     manager.publish("NORMAL1", :priority => TomQueue::NORMAL_PRIORITY)
     manager.publish("HIGH2", :priority => TomQueue::HIGH_PRIORITY)
     manager.publish("NORMAL2", :priority => TomQueue::NORMAL_PRIORITY)
 
-    consumer.pop.ack!.payload.should == "HIGH1"
-    consumer.pop.ack!.payload.should == "HIGH2"
-    consumer2.pop.ack!.payload.should == "NORMAL1"
-    consumer.pop.ack!.payload.should == "NORMAL2"
+    expect(consumer.pop.ack!.payload).to eq("HIGH1")
+    expect(consumer.pop.ack!.payload).to eq("HIGH2")
+    expect(consumer2.pop.ack!.payload).to eq("NORMAL1")
+    expect(consumer.pop.ack!.payload).to eq("NORMAL2")
 
-    consumer2.pop.ack!.payload.should == "stuff 3"
+    expect(consumer2.pop.ack!.payload).to eq("stuff 3")
   end
 
   it "should allow a message to be deferred for future execution", deferred_work_manager: true do
@@ -137,7 +137,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
     manager.publish("future-work", :run_at => execution_time )
 
     consumer.pop.ack!
-    Time.now.to_f.should > execution_time.to_f
+    expect(Time.now.to_f).to be > execution_time.to_f
   end
 
   it "uses the supplied publisher for immediate publication" do
@@ -271,7 +271,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
       sink_order = consumers.map { |c| c.work }.flatten.sort.map { |a| a.payload }
 
       # HACK: ignore the ordering as it is flaky, given all the threading going on.
-      Set.new(source_order).should == Set.new(sink_order)
+      expect(Set.new(source_order)).to eq(Set.new(sink_order))
     end
 
     it "should be able to drain the queue, block and resume when new work arrives" do
@@ -315,7 +315,7 @@ describe TomQueue::QueueManager, "simple publish / pop" do
       sink_order = consumers.map { |c| c.work }.flatten.sort.map { |a| a.payload }
 
       # HACK: ignore the ordering as it is flaky, given all the threading going on.
-      Set.new(sink_order).should == Set.new(source_order)
+      expect(Set.new(sink_order)).to eq(Set.new(source_order))
     end
 
     it "should work with lots of deferred work on the queue, and still schedule all messages", deferred_work_manager: true do
@@ -344,11 +344,11 @@ describe TomQueue::QueueManager, "simple publish / pop" do
       consumers.each do |c|
         total_size += c.work.size
         c.work.each do |work|
-          work.received_at.should < (work.run_at + 1.0)
+          expect(work.received_at).to be < (work.run_at + 1.0)
         end
       end
 
-      total_size.should == 200
+      expect(total_size).to eq(200)
     end
   end
 

--- a/spec/tom_queue/tom_queue_spec.rb
+++ b/spec/tom_queue/tom_queue_spec.rb
@@ -5,11 +5,11 @@ describe TomQueue, "module functions" do
   it "should store and return a shared bunny instance" do
     new_bunny = double(Bunny)
     TomQueue.bunny = new_bunny
-    TomQueue.bunny.should == new_bunny
+    expect(TomQueue.bunny).to eq(new_bunny)
   end
 
   it "should store and return a default_prefix" do
     TomQueue.default_prefix = "foobar"
-    TomQueue.default_prefix.should == "foobar"
+    expect(TomQueue.default_prefix).to eq("foobar")
   end
 end

--- a/spec/tom_queue/work_spec.rb
+++ b/spec/tom_queue/work_spec.rb
@@ -6,29 +6,29 @@ describe TomQueue::Work do
   let(:work) { TomQueue::Work.new(manager, :response, {'headers' => true}, 'payload') }
 
   it "should expose the queue manager" do
-    work.manager.should == manager
+    expect(work.manager).to eq(manager)
   end
   it "should expose the payload" do
-    work.payload.should == 'payload'
+    expect(work.payload).to eq('payload')
   end
   it "should expose the headers" do
-    work.headers.should == {'headers' => true}
+    expect(work.headers).to eq({'headers' => true})
   end
   it "should expose the amqp response object" do
-    work.response.should == :response
+    expect(work.response).to eq(:response)
   end
 
   describe "ack! sugar function" do
     before do
-      manager.stub(:ack => nil)
+      allow(manager).to receive(:ack).and_return(nil)
     end
 
     it "should call the queue_manager#ack(self)" do
-      manager.should_receive(:ack)
+      expect(manager).to receive(:ack)
       work.ack!
     end
     it "should return self" do
-      work.ack!.should == work
+      expect(work.ack!).to eq(work)
     end
   end
 


### PR DESCRIPTION
Use transpec gem to upgrade Rspec syntax to v3

This is based on branch `remove-generic-backend` as this has the most stable tests.

`remove-generic-backend` is based on `spike-move-dj-dependency-into-tomqueue` and so there are a few branches at play here, I should look at getting them merged into `v3`.