### PR TITLE
Add job_limit option

### DIFF
--- a/lib/tom_queue.rb
+++ b/lib/tom_queue.rb
@@ -19,7 +19,7 @@ module TomQueue
 
   require "tom_queue/sorted_array"
 
-  mattr_accessor :bunny, :publisher, :default_prefix
+  mattr_accessor :bunny, :publisher, :default_prefix, :job_limit
 
   self.publisher = Publisher.new
 


### PR DESCRIPTION
Setting `TomQueue.job_limit` to some value > 0 will cause the worker to
exit after processing that number of jobs.

We currently triggering a bug somewhere which causes the number of
consumers in RabbitMQ to keep growing eventually resulting in timeout
errors. These timeout errors can sometimes cause the job workers to
enter a state where they are still running but not processing any more
jobs.

This only manifests itself when the job workers haven't been restarted
for a number of days.

To mitigate this now we get the job worker to exit after specified
number of jobs and then, in our case, supervisord will restart it.