### PR TITLE
Tomqueue 2.2.0

### DIFF
--- a/lib/tom_queue/version.rb
+++ b/lib/tom_queue/version.rb
@@ -1,3 +1,3 @@
 module TomQueue
-  VERSION = "2.1.1"
+  VERSION = "2.2.0"
 end


### PR DESCRIPTION
Adds a job_limit setting, after which the delayed job worker will send
itself a TERM signal.