### PR TITLE
Upgrade TomQueue Version

### DIFF
--- a/lib/delayed_job.rb
+++ b/lib/delayed_job.rb
@@ -1,4 +1,3 @@
-$stderr.puts "require 'delayed_job' is deprecated, migrate to require 'tom_queue'"
 caller.each { |e| $stderr.puts "\t#{e}"}
 
 require 'active_support'

--- a/lib/delayed_job_active_record.rb
+++ b/lib/delayed_job_active_record.rb
@@ -1,4 +1,3 @@
-$stderr.puts "require 'delayed_job_active_record' is deprecated, migrate to require 'tom_queue'"
 caller.each { |e| $stderr.puts "\t#{e}"}
 
 require "delayed_job"

--- a/lib/tom_queue.rb
+++ b/lib/tom_queue.rb
@@ -7,6 +7,7 @@
 # into shards using ZooKeeper.
 #
 ##
+puts "TomQueue version: #{TomQueue::VERSION}"
 
 require "zeitwerk"
 

--- a/lib/tom_queue/version.rb
+++ b/lib/tom_queue/version.rb
@@ -1,3 +1,3 @@
 module TomQueue
-  VERSION = "2.1.1"
+  VERSION = "3.0.0.pre1"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,9 +25,6 @@ begin
 rescue LoadError
 end
 
-require 'active_record'
-require 'delayed_job'
-
 require 'delayed/backend/shared_spec'
 
 Delayed::Worker.logger = Logger.new('/tmp/dj.log')


### PR DESCRIPTION
* Updates the version in the Gemfile
* Prints the version (so we know for certain we're actually using it)
* Removes deprecation warnings because they were a bit noisy 