### PR TITLE
Remove rails maximum version constraint from gemspec

### DIFF
--- a/lib/tom_queue/version.rb
+++ b/lib/tom_queue/version.rb
@@ -1,3 +1,3 @@
 module TomQueue
-  VERSION = "2.2.0"
+  VERSION = "2.2.1"
 end

--- a/tom_queue.gemspec
+++ b/tom_queue.gemspec
@@ -3,7 +3,7 @@
 require_relative "lib/tom_queue/version"
 
 Gem::Specification.new do |spec|
-  spec.add_dependency   'activerecord', '>= 4.1', '< 6.1'
+  spec.add_dependency   'activerecord', '>= 4.1'
   spec.add_dependency   'delayed_job_active_record'
   spec.add_dependency   'bunny', "~> 2.2"
   spec.authors        = ["Thomas Haggett"]


### PR DESCRIPTION
To allow upgrades to Rails >= 6.1.