### PR TITLE
Add in a Datadog integration class to emulate DJ

### DIFF
--- a/lib/tom_queue.rb
+++ b/lib/tom_queue.rb
@@ -16,6 +16,7 @@ loader.ignore("#{__dir__}/generators")
 loader.ignore("#{__dir__}/delayed_job.rb")
 loader.ignore("#{__dir__}/delayed_job_active_record.rb")
 loader.ignore("#{__dir__}/tom_queue/tasks.rb")
+loader.ignore("#{__dir__}/tom_queue/datadog_integration.rb")
 loader.setup
 
 require "active_support"

--- a/lib/tom_queue/datadog_integration.rb
+++ b/lib/tom_queue/datadog_integration.rb
@@ -1,0 +1,35 @@
+require 'ddtrace/contrib/delayed_job/integration'
+
+module Datadog
+  module Contrib
+    module DelayedJob
+      class TomQueueIntegration
+        include Contrib::Integration
+
+        MINIMUM_VERSION = Gem::Version.new('3.0.0.pre2')
+
+        register_as :tom_queue
+
+        def self.version
+          Gem.loaded_specs['tom_queue'] && Gem.loaded_specs['tom_queue'].version
+        end
+
+        def self.loaded?
+          !defined?(::Delayed).nil?
+        end
+
+        def self.compatible?
+          super && version >= MINIMUM_VERSION
+        end
+
+        def default_configuration
+          Configuration::Settings.new
+        end
+
+        def patcher
+          Patcher
+        end
+      end
+    end
+  end
+end

--- a/lib/tom_queue/version.rb
+++ b/lib/tom_queue/version.rb
@@ -1,3 +1,3 @@
 module TomQueue
-  VERSION = "3.0.1.pre1"
+  VERSION = "3.0.1.pre2"
 end


### PR DESCRIPTION
… plugin, but changes the version constraints.

Bumps version to 3.0.0.pre2