### PR TITLE
Use Delayed::Worker over TomQueue::Worker

### DIFF
--- a/bin/tomqueued
+++ b/bin/tomqueued
@@ -12,4 +12,4 @@ require "tom_queue/worker"
 
 @worker_options[:sleep_delay] = ENV['SLEEP_DELAY'].to_i if ENV['SLEEP_DELAY']
 
-TomQueue::Worker.new(@worker_options).start
+Delayed::Worker.new(@worker_options).start

--- a/lib/tom_queue/version.rb
+++ b/lib/tom_queue/version.rb
@@ -1,3 +1,3 @@
 module TomQueue
-  VERSION = "3.0.1.pre2"
+  VERSION = "3.0.1.pre3"
 end


### PR DESCRIPTION
This is a temporary change needed to ensure jobs get picked up. To use
TomQueue::Worker we would need to update other references throught TQ,
which isn't the priority just now.