### PR TITLE
Introduce forked worker

### DIFF
--- a/bin/tomqueued
+++ b/bin/tomqueued
@@ -1,7 +1,6 @@
 #!/usr/bin/env ruby
 
 require "./config/environment"
-require "tom_queue/worker"
 
 @worker_options = {
   :min_priority => ENV['MIN_PRIORITY'],
@@ -12,4 +11,10 @@ require "tom_queue/worker"
 
 @worker_options[:sleep_delay] = ENV['SLEEP_DELAY'].to_i if ENV['SLEEP_DELAY']
 
-Delayed::Worker.new(@worker_options).start
+supervisor = TomQueue::WorkerSupervisor.new
+supervisor.before_fork = Rails.application.config.before_fork
+supervisor.after_fork = Rails.application.config.after_fork
+supervisor.supervise(as: "worker") do
+  Delayed::Worker.new(@worker_options).start
+end
+supervisor.run


### PR DESCRIPTION
This commit makes use of our new WorkerSupervisor to fork multiple
workers. We can specify a number of workers via the JOB_WORKERS env
variable.

## Acceptance criteria

- [x] The executable file uses the worker supervisor
- [x] Load the app in a before_fork hook, so we use much less memory
- [x] Move before_fork/after_fork logic into app
- [x] Workers defaults to 1 for now

_(Pulling the following out into another PR)_
- [ ] We can specify the number of workers via OptionParser (e.g. `--workers $JOB_WORKERS`)
