### PR TITLE
Add method to check if we're currently in a worker

### DIFF
--- a/lib/tom_queue.rb
+++ b/lib/tom_queue.rb
@@ -48,5 +48,9 @@ module TomQueue
   class << self
     attr_accessor :exception_reporter
     attr_accessor :logger
+
+    def in_worker?
+      /tomqueue/.match? $PROGRAM_NAME
+    end
   end
 end

--- a/lib/tom_queue/version.rb
+++ b/lib/tom_queue/version.rb
@@ -1,3 +1,3 @@
 module TomQueue
-  VERSION = "3.0.1.pre3"
+  VERSION = "3.0.1.pre4"
 end


### PR DESCRIPTION
We've added this so that we can tag logs correctly in apps that use
tomqueue. e.g. if we're logging while in a tomqueue process we want to
tag those logs appropriately.