### PR TITLE
Move the Deferred scheduler inside the TQ supervisor

### DIFF
--- a/bin/tomqueued
+++ b/bin/tomqueued
@@ -3,20 +3,22 @@
 require "./config/environment"
 require 'optparse'
 
-@worker_options = {
-  :min_priority => ENV['MIN_PRIORITY'],
-  :max_priority => ENV['MAX_PRIORITY'],
-  :queues => (ENV['QUEUES'] || ENV['QUEUE'] || '').split(','),
-  :quiet => ENV['QUIET']
+options = {
+  workers: 1,
+  deferred_scheduler: false,
+  executable_path: "./config/tom_queue_config.rb",
 }
 
-@worker_options[:sleep_delay] = ENV['SLEEP_DELAY'].to_i if ENV['SLEEP_DELAY']
-
-options = {workers: 1}
 OptionParser.new do |parser|
   parser.banner = "Usage: bundle exec tomqueued [options]"
   parser.on("-w", "--workers WORKERS", Integer, "The number of workers to fork (defaults to #{options[:workers]})") do |workers|
     options[:workers] = workers
+  end
+  parser.on("-d", "--deferred-scheduler", TrueClass, "Spin up the deferred scheduler (defaults to #{options[:deferred_scheduler]})") do
+    options[:deferred_scheduler] = true
+  end
+  parser.on("-e", "--execute FILE", "Execute a ruby script with access to @tomqueue_supervisor") do |path|
+    options[:executable_path] = path
   end
   parser.on("-h", "--help", "Prints this help") do
     puts parser
@@ -24,10 +26,28 @@ OptionParser.new do |parser|
   end
 end.parse!
 
-supervisor = TomQueue::WorkerSupervisor.new
-supervisor.before_fork = Rails.application.config.before_fork
-supervisor.after_fork = Rails.application.config.after_fork
-supervisor.supervise(as: "worker", count: options[:workers]) do
+@tomqueue_supervisor = TomQueue::WorkerSupervisor.new
+if options[:executable_path]
+  require options[:executable_path]
+end
+
+@tomqueue_supervisor.supervise(as: "worker", count: options[:workers]) do
+  @worker_options = {
+    :min_priority => ENV['MIN_PRIORITY'],
+    :max_priority => ENV['MAX_PRIORITY'],
+    :queues => (ENV['QUEUES'] || ENV['QUEUE'] || '').split(','),
+    :quiet => ENV['QUIET']
+  }
+
+  @worker_options[:sleep_delay] = ENV['SLEEP_DELAY'].to_i if ENV['SLEEP_DELAY']
+
   Delayed::Worker.new(@worker_options).start
 end
-supervisor.run
+
+if options[:deferred_scheduler]
+  @tomqueue_supervisor.supervise(as: "deferred_scheduler") do
+    TomQueue::DeferredWorkManager.new.start
+  end
+end
+
+@tomqueue_supervisor.run


### PR DESCRIPTION
This change means that we can control the workers and the deferred
scheduler under the same process tree. Currently, all the workers are
under the same process tree, but the deferred scheduler runs in an
entirely separate process.