### PR TITLE
Timeout for deferred message acks

### DIFF
--- a/lib/tom_queue/version.rb
+++ b/lib/tom_queue/version.rb
@@ -1,3 +1,3 @@
 module TomQueue
-  VERSION = "3.0.1.pre4"
+  VERSION = "3.1.0"
 end


### PR DESCRIPTION
Later versions of RabbitMQ will timeout unacknowledged messages, so
let's ensure we always acknowledge them after 10 minutes. 

Then they will be republished and either put on one of the work queues if they are ready
to run, or republished to the deferred queue if not.
